### PR TITLE
Propagate errors in callbacks

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -511,9 +511,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         let off = (block * block_size + off) as usize;
         let buf: &mut [u8] = unsafe { slice::from_raw_parts_mut(buffer as *mut u8, size as usize) };
 
-        // TODO
-        storage.read(off, buf).unwrap();
-        0
+        io::error_code_from(storage.read(off, buf))
     }
 
     /// C callback interface used by LittleFS to program data with the lower level system below the
@@ -533,9 +531,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         let off = (block * block_size + off) as usize;
         let buf: &[u8] = unsafe { slice::from_raw_parts(buffer as *const u8, size as usize) };
 
-        // TODO
-        storage.write(off, buf).unwrap();
-        0
+        io::error_code_from(storage.write(off, buf))
     }
 
     /// C callback interface used by LittleFS to erase data with the lower level system below the
@@ -548,9 +544,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         let storage = unsafe { &mut *((*c).context as *mut Storage) };
         let off = block as usize * Storage::BLOCK_SIZE as usize;
 
-        // TODO
-        storage.erase(off, Storage::BLOCK_SIZE as usize).unwrap();
-        0
+        io::error_code_from(storage.erase(off, Storage::BLOCK_SIZE as usize))
     }
 
     /// C callback interface used by LittleFS to sync data with the lower level interface below the

--- a/src/io.rs
+++ b/src/io.rs
@@ -138,6 +138,29 @@ impl From<crate::path::Error> for Error {
     }
 }
 
+impl From<Error> for ll::lfs_error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::Success => ll::lfs_error_LFS_ERR_OK,
+            Error::Io => ll::lfs_error_LFS_ERR_IO,
+            Error::Corruption => ll::lfs_error_LFS_ERR_CORRUPT,
+            Error::NoSuchEntry => ll::lfs_error_LFS_ERR_NOENT,
+            Error::EntryAlreadyExisted => ll::lfs_error_LFS_ERR_EXIST,
+            Error::PathNotDir => ll::lfs_error_LFS_ERR_NOTDIR,
+            Error::PathIsDir => ll::lfs_error_LFS_ERR_ISDIR,
+            Error::DirNotEmpty => ll::lfs_error_LFS_ERR_NOTEMPTY,
+            Error::BadFileDescriptor => ll::lfs_error_LFS_ERR_BADF,
+            Error::FileTooBig => ll::lfs_error_LFS_ERR_FBIG,
+            Error::Invalid => ll::lfs_error_LFS_ERR_INVAL,
+            Error::NoSpace => ll::lfs_error_LFS_ERR_NOSPC,
+            Error::NoMemory => ll::lfs_error_LFS_ERR_NOMEM,
+            Error::NoAttribute => ll::lfs_error_LFS_ERR_NOATTR,
+            Error::FilenameTooLong => ll::lfs_error_LFS_ERR_NAMETOOLONG,
+            Error::Unknown(error_code) => error_code,
+        }
+    }
+}
+
 impl From<i32> for Error {
     fn from(error_code: i32) -> Error {
         match error_code {
@@ -161,6 +184,10 @@ impl From<i32> for Error {
             _ => Error::Unknown(error_code),
         }
     }
+}
+
+pub fn error_code_from<T>(result: Result<T>) -> ll::lfs_error {
+    result.err().unwrap_or(Error::Success).into()
 }
 
 pub fn result_from<T>(return_value: T, error_code: ll::lfs_error) -> Result<T> {


### PR DESCRIPTION
Instead of panicking if an operation in a callback fails, convert the Rust enum to an error code and return it to littlefs2.