### PR TITLE
driver::Storage::read(&self -> &mut self)

### DIFF
--- a/src/driver.rs
+++ b/src/driver.rs
@@ -91,7 +91,7 @@ pub trait Storage {
 
     /// Read data from the storage device.
     /// Guaranteed to be called only with bufs of length a multiple of READ_SIZE.
-    fn read(&self, off: usize, buf: &mut [u8]) -> Result<usize>;
+    fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize>;
     /// Write data to the storage device.
     /// Guaranteed to be called only with bufs of length a multiple of WRITE_SIZE.
     fn write(&mut self, off: usize, data: &[u8]) -> Result<usize>;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -505,7 +505,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         size: ll::lfs_size_t,
     ) -> cty::c_int {
         // println!("in lfs_config_read for {} bytes", size);
-        let storage = unsafe { &*((*c).context as *const Storage) };
+        let storage = unsafe { &mut *((*c).context as *mut Storage) };
         debug_assert!(!c.is_null());
         let block_size = unsafe { c.read().block_size };
         let off = (block * block_size + off) as usize;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -51,7 +51,7 @@ macro_rules! ram_storage { (
             const BLOCK_COUNT: usize = $block_count;
             type LOOKAHEADWORDS_SIZE = $lookaheadwords_size;
 
-            fn read(&self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
+            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
                 let read_size: usize = Self::READ_SIZE;
                 debug_assert!(offset % read_size == 0);
                 debug_assert!(buf.len() % read_size == 0);
@@ -180,7 +180,7 @@ macro_rules! const_ram_storage { (
             const BLOCK_COUNT: usize = $block_count;
             type LOOKAHEADWORDS_SIZE = $lookaheadwords_size;
 
-            fn read(&self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
+            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
                 let read_size: usize = Self::READ_SIZE;
                 debug_assert!(offset % read_size == 0);
                 debug_assert!(buf.len() % read_size == 0);


### PR DESCRIPTION
The definition with an immutable self clashes with the [`ReadStorage`](https://docs.rs/embedded-storage/latest/embedded_storage/trait.ReadStorage.html) trait from the embedded_storage crate which has read(&mut self, ...). Allowing the object to be mutated is more generic, so change our Storage trait accordingly.