### PR TITLE
Support constructing const Path from str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added `Path::from_str_with_nul` and `path!` to create `Path` instances from
+  `str`.
+
+### Changed
+- Made `Path::from_bytes_with_nul_unchecked` `const`.
+
 ## [v0.2.2] - 2021-03-20
 
 ### Changed

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1311,7 +1311,6 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
 mod tests {
     use super::*;
     use core::convert::TryInto;
-    use generic_array::typenum::consts;
     use driver::Storage as LfsStorage;
     use io::Result as LfsResult;
     const_ram_storage!(TestStorage, 4096);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,5 +161,35 @@ pub struct Version {
     pub backend: (u32, u32),
 }
 
+/// Creates a path from a string without a trailing null.
+///
+/// Panics if the string contains null bytes or non-ascii characters.
+///
+/// # Examples
+///
+/// ```
+/// use littlefs2::{path, path::Path};
+///
+/// const HOME: &Path = path!("/home");
+/// ```
+///
+/// Illegal values:
+///
+/// ```compile_fail
+/// # use littlefs2::{path, path::Path};
+/// const WITH_NULL: &Path = path!("/h\0me");  // does not compile
+/// ```
+///
+/// ```compile_fail
+/// # use littlefs2::{path, path::Path};
+/// const WITH_UTF8: &Path = path!("/höme");  // does not compile
+/// ```
+#[macro_export]
+macro_rules! path {
+    ($path:literal) => {
+        Path::from_str_with_nul(::core::concat!($path, "\0"))
+    };
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/path.rs
+++ b/src/path.rs
@@ -441,14 +441,26 @@ mod tests {
     const EMPTY: &Path = path!("");
     const SLASH: &Path = path!("/");
 
+    #[test]
+    fn path_macro() {
+        assert_eq!(EMPTY, &*PathBuf::from(""));
+        assert_eq!(SLASH, &*PathBuf::from("/"));
+    }
+
     // does not compile:
     // const NON_ASCII: &Path = path!("über");
     // const NULL: &Path = path!("ub\0er");
 
     #[test]
-    fn path_macro() {
-        assert_eq!(EMPTY, &*PathBuf::from(""));
-        assert_eq!(SLASH, &*PathBuf::from("/"));
+    #[should_panic]
+    fn nul_in_from_str_with_nul() {
+        Path::from_str_with_nul("ub\0er");
+    }
+
+    #[test]
+    #[should_panic]
+    fn non_ascii_in_from_str_with_nul() {
+        Path::from_str_with_nul("über");
     }
 
     #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,5 +1,4 @@
 use littlefs2::{
-    consts,
     driver,
     fs::Filesystem,
     io::Result,


### PR DESCRIPTION
Previously, we could simply construct a PathBuf from a str using PathBuf::from, but not a Path.  This patch changes this by adding the Path::from_str_with_nul method and the path! macro.  This even makes it possible to create Path constants.