### PR TITLE
Fix deletion of root directory

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -13,6 +13,7 @@ pub type Bytes<SIZE> = generic_array::GenericArray<u8, SIZE>;
 use crate::{
     driver,
     io::{self, OpenSeekFrom, Result},
+    path,
     path::{Path, PathBuf},
 };
 
@@ -358,7 +359,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
             }
             Ok(())
         })?;
-        if !skipped_any {
+        if !skipped_any && path != path!("") && path != path!("/") {
             debug_now!("removing directory {} too", &path);
             self.remove_dir(path)?;
             debug_now!("..worked");


### PR DESCRIPTION
This PR adds a check in the remove_dir_all method to avoid removing the root directory. This Gives a simple fix to the case where one wants to remove all files in the filesystem, and therefore calls remove_dir_all on `/`, which would previously fail because it can't delete the root.

Fix #45 