### PR TITLE
Fixes undefined behavior due to improper use of `&mut`

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -620,7 +620,7 @@ bitflags! {
 
 /// The state of a `File`. Pre-allocate with `File::allocate`.
 pub struct FileAllocation<S: driver::Storage> {
-    cache: Bytes<S::CACHE_SIZE>,
+    cache: UnsafeCell<Bytes<S::CACHE_SIZE>>,
     state: ll::lfs_file_t,
     config: ll::lfs_file_config,
 }
@@ -823,7 +823,7 @@ impl OpenOptions {
         alloc: &'b mut FileAllocation<S>,
         path: &Path,
     ) -> Result<File<'a, 'b, S>> {
-        alloc.config.buffer = &mut alloc.cache as *mut _ as *mut cty::c_void;
+        alloc.config.buffer = alloc.cache.get() as *mut _;
 
         let return_code = ll::lfs_file_opencfg(
             &mut fs.alloc.borrow_mut().state,


### PR DESCRIPTION
These commits fix multiple instances of undefined behavior as originally discussed via email with @sosthene-nitrokey.

### Issue 1 - `Allocation` is self-referential

The struct `Allocation` is initialized so that its config retains multiple references to the cache. 
```
alloc.config.buffer = & mut alloc.cache *mut _ as *mut cty::c_void;
```
When this reference or any other reference to one of the caches within `alloc` is mutated in C, it will invalidate all other mutable references to `alloc`. Wrapping each cache in an `UnsafeCell` prevents this from occurring, since foreign writes do not affect the validity of a permission to a location if that location is covered by an `UnsafeCell`. 

### Issue 2 - Linked lists retain mutable pointers

The structure of the C API uses multiple linked lists to contain objects of type `lfs_file` and `lfs_dir`. For example:
```
pub struct lfs_file {
    pub next: *mut lfs_file
    ...
} 
```
This means that it is unsound to mutably borrow these structs in Rust, since we cannot assume unique mutable access. Using `addr_of_mut!` instead of `&mut` ensures that we never assume that we have unique access to `alloc.state`. 

With these changes, all tests pass Miri under the current version of Tree Borrows. 