### PR TITLE
Add Filesystem::mount_or_else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Added
 - Added object-safe traits `DynFile`, `DynFilesystem` and `DynStorage` for
   accessing `Storage`, `Filesystem` and `File` implementations for any storage.
+- Added `Filesystem::mount_or_else` function ([#57][])
 
 ## Fixed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added path iteration utilities ([#47][])
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
+[#57]: https://github.com/trussed-dev/littlefs2/pull/57
 
 ## [v0.4.0] - 2023-02-07
 


### PR DESCRIPTION
When mounting a filesystem, often code like this is used:

```
if !Filesystem::is_mountable(alloc, storage) {
    Filesystem::format(storage).ok();
}
Filesystem::mount(alloc, storage)
```

This mounts the filesystem twice because Filesystem::is_mountable is equivalent to Filesystem::mount(...).is_ok().  Depending on the storage implementation, mounting the filesystem can have significant cost. But directly calling Filesystem::mount and re-mounting in the error case is prohibited by the borrow checker.

This patch adds a mount_or_else method that accepts a callable that is called on mount error.  Afterwards, mounting is re-tried.