### PR TITLE
Initial support for upstream lfs v2.9.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-features = false
 version = "0.2"
 
 [dependencies.littlefs2-sys]
-version = "0.1.6"
+version = "0.2.0"
 
 [dependencies.serde]
 version = "1"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -50,6 +50,8 @@ pub struct Allocation<Storage: driver::Storage> {
     state: ll::lfs_t,
 }
 
+unsafe impl<T: driver::Storage + Send> Send for Allocation<T> {}
+
 // pub fn check_storage_requirements(
 
 impl<Storage: driver::Storage> Default for Allocation<Storage> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -131,6 +131,7 @@ impl<Storage: driver::Storage> Allocation<Storage> {
             block_cycles,
             cache_size,
             lookahead_size,
+            compact_thresh: u32::MAX,
 
             read_buffer: core::ptr::null_mut(),
             prog_buffer: core::ptr::null_mut(),
@@ -139,6 +140,8 @@ impl<Storage: driver::Storage> Allocation<Storage> {
             name_max: filename_max_plus_one.wrapping_sub(1),
             file_max,
             attr_max,
+            metadata_max: 0,
+            inline_max: u32::MAX,
         };
 
         Self {


### PR DESCRIPTION
Please consider accepting this patch, as it allows depending on `littlefs2-sys` with current `lfs` version included.

There is a matching pull request in `littlefs2-sys` repo.

I set `littlefs2-sys` version to `0.2.0` for now, but that may need to be changed, depending on how the matching pull request in that crate is handled.