### PR TITLE
Enforce const evaluation in path! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed build error that would occur on Windows systems.
 - Added path iteration utilities ([#47][])
 
+## Changed
+
+- Enforced const evaluation for `path!`.
+
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57
 


### PR DESCRIPTION
By using a temporary const value, we can enforce that the path! macro always causes a compiler error for illegal values even if it is not used in a const context.  This makes it easier to write correct code.