### PR TITLE
Remove panicking path conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added object-safe traits `DynFile`, `DynFilesystem` and `DynStorage` for
   accessing `Storage`, `Filesystem` and `File` implementations for any storage.
 - Added `Filesystem::mount_or_else` function ([#57][])
+- Marked `Path::is_empty`, `Path::from_bytes_with_nul`, `Path::from_cstr`, `Path::from_cstr_unchecked`, `Path::as_str_ref_with_trailing_nul`, `Path::as_str`, and `PathBuf::new` as `const`.
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Enforced const evaluation for `path!`.
 - Removed `cstr_core` and `cty` dependencies.
 - Updated `littlefs2-sys` dependency to 0.2.0.
+- Replace all panicking `Path`/`PathBuf` conversions with fallible alternatives:
+  - Return a `Result` from `Path::from_str_with_nul`.
+  - Replace the `From<_>` implementations for `Path` and `PathBuf` with `TryFrom<_>`, except for `From<&Path> for PathBuf`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,28 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## Added
+### Added
 - Added object-safe traits `DynFile`, `DynFilesystem` and `DynStorage` for
   accessing `Storage`, `Filesystem` and `File` implementations for any storage.
 - Added `Filesystem::mount_or_else` function ([#57][])
 - Marked `Path::is_empty`, `Path::from_bytes_with_nul`, `Path::from_cstr`, `Path::from_cstr_unchecked`, `Path::as_str_ref_with_trailing_nul`, `Path::as_str`, and `PathBuf::new` as `const`.
 
-## Fixed
+### Fixed
 
 - Fixed macro hygiene for `path!`.
 - Fixed build error that would occur on Windows systems.
 - Fixed compilation without default features.
 - Added path iteration utilities ([#47][])
 
-## Changed
+### Changed
 
 - Enforced const evaluation for `path!`.
 - Removed `cstr_core` and `cty` dependencies.
 - Updated `littlefs2-sys` dependency to 0.2.0.
+
+### Removed
+
+- Removed `Path::from_bytes_with_nul_unchecked`.  Use `CStr::from_bytes_with_nul_unchecked` and `Path::from_cstr_unchecked` instead.
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1254,7 +1254,7 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
         let path_slice = path.as_ref().as_bytes();
         for i in 0..path_slice.len() {
             if path_slice[i] == b'/' {
-                let dir = PathBuf::from(&path_slice[..i]);
+                let dir = PathBuf::try_from(&path_slice[..i])?;
                 #[cfg(test)]
                 println!("generated PathBuf dir {:?} using i = {}", &dir, i);
                 match self.create_dir(&dir) {
@@ -1362,6 +1362,7 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::path;
     use core::convert::TryInto;
     use driver::Storage as LfsStorage;
     use io::Result as LfsResult;
@@ -1483,7 +1484,7 @@ mod tests {
                 // (...)
                 // fs.remove_dir_all(&PathBuf::from(b"/tmp\0"))?;
                 // fs.remove_dir_all(&PathBuf::from(b"/tmp"))?;
-                fs.remove_dir_all(&PathBuf::from("/tmp"))?;
+                fs.remove_dir_all(path!("/tmp"))?;
             }
 
             Ok(())
@@ -1493,7 +1494,7 @@ mod tests {
         let mut alloc = Allocation::new();
         let fs = Filesystem::mount(&mut alloc, &mut test_storage).unwrap();
         // fs.write(b"/z.txt\0".try_into().unwrap(), &jackson5).unwrap();
-        fs.write(&PathBuf::from("z.txt"), jackson5).unwrap();
+        fs.write(path!("z.txt"), jackson5).unwrap();
     }
 
     #[cfg(feature = "dir-entry-path")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ Separately, keeping track of the allocations is a chore, we hope that
 ```
 # use littlefs2::fs::{Filesystem, File, OpenOptions};
 # use littlefs2::io::prelude::*;
-# use littlefs2::path::PathBuf;
+# use littlefs2::path;
 #
 # use littlefs2::{consts, ram_storage, driver, io::Result};
 #
@@ -113,7 +113,7 @@ let mut fs = Filesystem::mount(&mut alloc, &mut storage).unwrap();
 let mut buf = [0u8; 11];
 fs.open_file_with_options_and_then(
     |options| options.read(true).write(true).create(true),
-    &PathBuf::from(b"example.txt"),
+    path!("example.txt"),
     |file| {
         file.write(b"Why is black smoke coming out?!")?;
         file.seek(SeekFrom::End(-24)).unwrap();
@@ -199,7 +199,10 @@ pub struct Version {
 macro_rules! path {
     ($path:literal) => {{
         const _PATH: &$crate::path::Path =
-            $crate::path::Path::from_str_with_nul(::core::concat!($path, "\0"));
+            match $crate::path::Path::from_str_with_nul(::core::concat!($path, "\0")) {
+                Ok(path) => path,
+                Err(_) => panic!("invalid littlefs2 path"),
+            };
         _PATH
     }};
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -195,20 +195,20 @@ fn test_create() {
         assert_eq!(fs.available_blocks().unwrap(), 512 - 2);
         assert_eq!(fs.available_space().unwrap(), 130_560);
 
-        assert!(!crate::path::PathBuf::from(b"/test_open.txt").exists(fs));
+        assert!(!path!("/test_open.txt").exists(fs));
         assert_eq!(
             File::open_and_then(fs, b"/test_open.txt\0".try_into().unwrap(), |_| { Ok(()) })
                 .map(drop)
                 .unwrap_err(), // "real" contains_err is experimental
             Error::NoSuchEntry
         );
-        assert!(!crate::path::PathBuf::from(b"/test_open.txt").exists(fs));
+        assert!(!path!("/test_open.txt").exists(fs));
 
         fs.create_dir(b"/tmp\0".try_into().unwrap()).unwrap();
         assert_eq!(fs.available_blocks().unwrap(), 512 - 2 - 2);
 
         // can create new files
-        assert!(!crate::path::PathBuf::from(b"/tmp/test_open.txt").exists(fs));
+        assert!(!path!("/tmp/test_open.txt").exists(fs));
         fs.create_file_and_then(b"/tmp/test_open.txt\0".try_into().unwrap(), |file| {
             // can write to files
             assert!(file.write(&[0u8, 1, 2]).unwrap() == 3);
@@ -219,7 +219,7 @@ fn test_create() {
             // file.close()?;
             Ok(())
         })?;
-        assert!(crate::path::PathBuf::from(b"/tmp/test_open.txt").exists(fs));
+        assert!(path!("/tmp/test_open.txt").exists(fs));
 
         // // cannot remove non-empty directories
         assert_eq!(


### PR DESCRIPTION
This patch changes all constructors and conversion traits for `Path` and `PathBuf` to be fallible (except for `From<&Path> for PathBuf`).  It also adds explicit invariants to the path types and marks its functions as const where possible.

Fixes: https://github.com/trussed-dev/littlefs2/issues/63