### PR TITLE
Remove deploy docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,3 @@ jobs:
 
       - name: Build Documentation
         run: cargo doc --no-deps
-
-      - name: Deploy Docs
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
-


### PR DESCRIPTION
This job no longer works so this patch removes it from the GitHub Actions workflow.  Users should refer to docs.rs instead.