### PR TITLE
Refactor error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Replace all panicking `Path`/`PathBuf` conversions with fallible alternatives:
   - Return a `Result` from `Path::from_str_with_nul`.
   - Replace the `From<_>` implementations for `Path` and `PathBuf` with `TryFrom<_>`, except for `From<&Path> for PathBuf`.
+- Refactor error types:
+  - Change `Error` enum to a struct with associated constants.
+  - Remove `Error::Success` and enforce negative values for `Error`.
 
 ### Removed
 
 - Removed `Path::from_bytes_with_nul_unchecked`.  Use `CStr::from_bytes_with_nul_unchecked` and `Path::from_cstr_unchecked` instead.
+- Removed `From<littlefs2::path::Error> for littlefs2::io::Error`.
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -243,7 +243,7 @@ impl dyn DynFilesystem + '_ {
     }
 
     pub fn create_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::Io);
+        let mut result = Err(Error::IO);
         self.create_file_and_then_unit(path, &mut |file| {
             result = Ok(f(file)?);
             Ok(())
@@ -252,7 +252,7 @@ impl dyn DynFilesystem + '_ {
     }
 
     pub fn open_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::Io);
+        let mut result = Err(Error::IO);
         self.open_file_and_then_unit(path, &mut |file| {
             result = Ok(f(file)?);
             Ok(())
@@ -266,7 +266,7 @@ impl dyn DynFilesystem + '_ {
         path: &Path,
         f: FileCallback<'_, R>,
     ) -> Result<R> {
-        let mut result = Err(Error::Io);
+        let mut result = Err(Error::IO);
         self.open_file_with_options_and_then_unit(o, path, &mut |file| {
             result = Ok(f(file)?);
             Ok(())
@@ -275,7 +275,7 @@ impl dyn DynFilesystem + '_ {
     }
 
     pub fn read_dir_and_then<R>(&self, path: &Path, f: DirEntriesCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::Io);
+        let mut result = Err(Error::IO);
         self.read_dir_and_then_unit(path, &mut |entries| {
             result = Ok(f(entries)?);
             Ok(())
@@ -372,7 +372,7 @@ impl<S: Storage> DynStorage for S {
 
 impl dyn DynStorage + '_ {
     pub fn mount_and_then<R>(&mut self, f: FilesystemCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::Io);
+        let mut result = Err(Error::IO);
         self.mount_and_then_unit(&mut |fs| {
             result = Ok(f(fs)?);
             Ok(())

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -56,7 +56,7 @@ fn format() {
         Filesystem::mount(&mut alloc, &mut storage)
             .map(drop)
             .unwrap_err(),
-        Error::Corruption
+        Error::CORRUPTION
     );
     // should succeed
     assert!(Filesystem::format(&mut storage).is_ok());
@@ -200,7 +200,7 @@ fn test_create() {
             File::open_and_then(fs, b"/test_open.txt\0".try_into().unwrap(), |_| { Ok(()) })
                 .map(drop)
                 .unwrap_err(), // "real" contains_err is experimental
-            Error::NoSuchEntry
+            Error::NO_SUCH_ENTRY
         );
         assert!(!path!("/test_open.txt").exists(fs));
 
@@ -224,7 +224,7 @@ fn test_create() {
         // // cannot remove non-empty directories
         assert_eq!(
             fs.remove(b"/tmp\0".try_into().unwrap()).unwrap_err(),
-            Error::DirNotEmpty
+            Error::DIR_NOT_EMPTY
         );
 
         let metadata = fs.metadata(b"/tmp\0".try_into().unwrap())?;
@@ -414,10 +414,10 @@ fn remove_dir_all_where() {
         })
         .unwrap();
         assert!(fs.metadata(path!("test_dir/test_file")).unwrap().is_file());
-        assert_eq!(fs.metadata(path!("test_file")), Err(Error::NoSuchEntry));
+        assert_eq!(fs.metadata(path!("test_file")), Err(Error::NO_SUCH_ENTRY));
         assert_eq!(
             fs.metadata(path!("test_dir/test_file2")),
-            Err(Error::NoSuchEntry)
+            Err(Error::NO_SUCH_ENTRY)
         );
         Ok(())
     })
@@ -474,15 +474,15 @@ fn test_iter_dirs() {
     let mut storage = RamStorage::new(&mut backend);
     Filesystem::format(&mut storage).unwrap();
     Filesystem::mount_and_then(&mut storage, |fs| {
-        fs.create_dir(b"/tmp\0".try_into()?)?;
+        fs.create_dir(path!("/tmp").into())?;
 
         // TODO: we might want "multi-open"
-        fs.create_file_and_then(b"/tmp/file.a\0".try_into()?, |file| {
+        fs.create_file_and_then(path!("/tmp/file.a"), |file| {
             file.set_len(37)?;
-            fs.create_file_and_then(b"/tmp/file.b\0".try_into()?, |file| file.set_len(42))
+            fs.create_file_and_then(path!("/tmp/file.b"), |file| file.set_len(42))
         })?;
 
-        fs.read_dir_and_then(b"/tmp\0".try_into()?, |dir| {
+        fs.read_dir_and_then(path!("/tmp"), |dir| {
             let mut found_files: usize = 0;
             let mut sizes = [0usize; 4];
 


### PR DESCRIPTION
This PR splits the `Error` enum into an `Error` struct and a non-exhaustive `ErrorKind` enum.  This makes it possible to add support for new error codes without breaking compatibility.  The PR also removes the edge case of `Error` instances for non-negative return values indicating success.

See this issue for context and discussion:
- https://github.com/trussed-dev/littlefs2/issues/55

Contrary to the suggestion in https://github.com/trussed-dev/littlefs2/issues/55#issuecomment-2024943423, this implementation does not provide a `fn error(&self) -> Option<ErrorKind>` on `Error`.  It would again cause the problem that users could rely on this method returning `None` for some currently unsupported error.  Instead, `Error` implements `PartialEq<ErrorKind>` so that users can compare it directly against known error kinds.  The only limitation is that it is not possible to `match` on the error kind, but I don’t see a need for that anyway.