### PR TITLE
Handle platforms where c_int is not i32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,53 @@ jobs:
       - name: Check documentation
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+
+  build-avr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          env && pwd && sudo apt-get update -y -qq && sudo apt-get install -y -qq llvm gcc-avr avr-libc libclang-dev
+
+      - name: Install rust
+        run: rustup toolchain install --profile minimal --component=rust-src nightly
+
+      - uses: actions/checkout@v3
+
+      - name: Configure target
+        run: |
+          cat <<EOT > avr-atmega328p.json
+          {
+            "arch": "avr",
+            "atomic-cas": false,
+            "cpu": "atmega328p",
+            "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
+            "eh-frame-header": false,
+            "exe-suffix": ".elf",
+            "late-link-args": {
+              "gcc": [
+                "-lgcc"
+              ]
+            },
+            "linker": "avr-gcc",
+            "llvm-target": "avr-unknown-unknown",
+            "max-atomic-width": 8,
+            "no-default-libraries": false,
+            "pre-link-args": {
+              "gcc": [
+                "-mmcu=atmega328p"
+              ]
+            },
+            "relocation-model": "static",
+            "target-c-int-width": "16",
+            "target-pointer-width": "16"
+          }
+          EOT
+
+      - name: Patch delog
+        run: echo 'delog = { version = "0.1.6", git = "https://github.com/LechevSpace/delog.git", rev = "e83f3fd" }' >> Cargo.toml
+
+      - name: Build avr
+        run: cargo +nightly build -Z build-std=core --target=./avr-atmega328p.json --workspace --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `Filesystem::mount_or_else` function ([#57][])
 - Marked `Path::is_empty`, `Path::from_bytes_with_nul`, `Path::from_cstr`, `Path::from_cstr_unchecked`, `Path::as_str_ref_with_trailing_nul`, `Path::as_str`, and `PathBuf::new` as `const`.
 - Made `fs::FileOpenFlags` public and added `From<fs::FileOpenFlags>` for `fs::OpenOptions`.
+- Support platforms where `c_int` is not `i32`.
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds a CI job that tests compatibility with an avr target (16-bit) and fixes code that assumes that `c_int` is always `i32`.

Replaces:
- https://github.com/trussed-dev/littlefs2/pull/68

One remaining problem is that some functions cast `u32` return values to `usize`.  In most cases that should be fine because the return value is limited by the length of the input buffer and thus fits into a `usize`.  One notable exemption is `seek`.  But let’s review and fix that separately.