### PR TITLE
Move exists method from Path into Filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactor error types:
   - Change `Error` enum to a struct with associated constants.
   - Remove `Error::Success` and enforce negative values for `Error`.
+- Replace `Path::exists` with `Filesystem::exists`
 
 ### Removed
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -332,7 +332,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
     {
         use crate::path;
 
-        if !path.exists(self) {
+        if !self.exists(path) {
             debug_now!("no such directory {}, early return", path);
             return Ok(RemoveDirAllProgress {
                 files_removed: 0,
@@ -398,6 +398,14 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
             )
         };
         io::result_from((), return_code)
+    }
+
+    /// Check whether a file or directory exists at a path.
+    ///
+    /// This is equivalent to calling [`Filesystem::metadata`][] and checking for an `Ok` return
+    /// value.
+    pub fn exists(&self, path: &Path) -> bool {
+        self.metadata(path).is_ok()
     }
 
     /// Given a path, query the filesystem to get information about a file or directory.

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -67,9 +67,6 @@ impl dyn DynFile + '_ {
 
 /// Object-safe trait for [`Filesystem`][].
 ///
-/// It contains these additional methods from [`Path`][]:
-/// - [`DynFilesystem::exists`][]
-///
 /// The following methods are implemented in [`DynStorage`][] instead:
 /// - [`DynStorage::format`][]
 /// - [`DynStorage::is_mountable`][]
@@ -100,6 +97,7 @@ pub trait DynFilesystem {
     #[cfg(feature = "dir-entry-path")]
     fn remove_dir_all_where(&self, path: &Path, predicate: Predicate<'_>) -> Result<usize>;
     fn rename(&self, from: &Path, to: &Path) -> Result<()>;
+    fn exists(&self, path: &Path) -> bool;
     fn metadata(&self, path: &Path) -> Result<Metadata>;
     fn create_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
     fn open_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
@@ -117,7 +115,6 @@ pub trait DynFilesystem {
     fn create_dir_all(&self, path: &Path) -> Result<()>;
     fn write(&self, path: &Path, contents: &[u8]) -> Result<()>;
     fn write_chunk(&self, path: &Path, contents: &[u8], pos: OpenSeekFrom) -> Result<()>;
-    fn exists(&self, path: &Path) -> bool;
 }
 
 impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
@@ -157,6 +154,10 @@ impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
 
     fn rename(&self, from: &Path, to: &Path) -> Result<()> {
         Filesystem::rename(self, from, to)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        Filesystem::exists(self, path)
     }
 
     fn metadata(&self, path: &Path) -> Result<Metadata> {
@@ -210,10 +211,6 @@ impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
 
     fn write_chunk(&self, path: &Path, contents: &[u8], pos: OpenSeekFrom) -> Result<()> {
         Filesystem::write_chunk(self, path, contents, pos)
-    }
-
-    fn exists(&self, path: &Path) -> bool {
-        path.exists(self)
     }
 }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -292,10 +292,6 @@ impl Path {
         p
     }
 
-    pub fn exists<S: crate::driver::Storage>(&self, fs: &crate::fs::Filesystem<S>) -> bool {
-        fs.metadata(self).is_ok()
-    }
-
     // helpful for debugging wither the trailing nul is indeed a trailing nul.
     pub const fn as_str_ref_with_trailing_nul(&self) -> &str {
         // SAFETY: ASCII is valid UTF-8

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -195,20 +195,20 @@ fn test_create() {
         assert_eq!(fs.available_blocks().unwrap(), 512 - 2);
         assert_eq!(fs.available_space().unwrap(), 130_560);
 
-        assert!(!path!("/test_open.txt").exists(fs));
+        assert!(!fs.exists(path!("/test_open.txt")));
         assert_eq!(
             File::open_and_then(fs, b"/test_open.txt\0".try_into().unwrap(), |_| { Ok(()) })
                 .map(drop)
                 .unwrap_err(), // "real" contains_err is experimental
             Error::NO_SUCH_ENTRY
         );
-        assert!(!path!("/test_open.txt").exists(fs));
+        assert!(!fs.exists(path!("/test_open.txt")));
 
         fs.create_dir(b"/tmp\0".try_into().unwrap()).unwrap();
         assert_eq!(fs.available_blocks().unwrap(), 512 - 2 - 2);
 
         // can create new files
-        assert!(!path!("/tmp/test_open.txt").exists(fs));
+        assert!(!fs.exists(path!("/tmp/test_open.txt")));
         fs.create_file_and_then(b"/tmp/test_open.txt\0".try_into().unwrap(), |file| {
             // can write to files
             assert!(file.write(&[0u8, 1, 2]).unwrap() == 3);
@@ -219,7 +219,7 @@ fn test_create() {
             // file.close()?;
             Ok(())
         })?;
-        assert!(path!("/tmp/test_open.txt").exists(fs));
+        assert!(fs.exists(path!("/tmp/test_open.txt")));
 
         // // cannot remove non-empty directories
         assert_eq!(


### PR DESCRIPTION
The Path::exists method requires access to a Filesystem instance.  This will be a problem once we move Path into a separate core crate (that does not have access to the Filesystem implementation).  Therefore, this patch replaces Path::exists with Filesystem::exists.