### PR TITLE
Introduce littlefs2-core crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,29 +30,29 @@ jobs:
 
       - name: Check
         run: |
-          cargo check --all-targets
-          cargo check --all-targets --all-features
-          cargo check --all-targets --no-default-features
-          cargo check --all-targets --no-default-features --features serde
-          cargo check --all-targets --no-default-features --features dir-entry-path
+          cargo check --workspace --all-targets
+          cargo check --workspace --all-targets --all-features
+          cargo check --workspace --all-targets --no-default-features
+          cargo check --workspace --all-targets --no-default-features --features serde
+          cargo check --workspace --all-targets --no-default-features --features dir-entry-path
 
       - name: Build
-        run: cargo build --release --verbose
+        run: cargo build --workspace --release --verbose
 
       - name: Run clippy
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo clippy --all-features --all-targets -- --deny warnings
+        run: cargo clippy --workspace --all-features --all-targets -- --deny warnings
 
       - name: Check code format
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Run tests
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: >
-          cargo test &&
-          cargo test --release
+          cargo test --workspace &&
+          cargo test --workspace --release
 
       - name: Check documentation
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps 
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `Path::from_bytes_with_nul_unchecked`.  Use `CStr::from_bytes_with_nul_unchecked` and `Path::from_cstr_unchecked` instead.
 - Removed `From<littlefs2::path::Error> for littlefs2::io::Error`.
 - Removed `object_safe::OpenOptionsCallback`.
+- Removed `consts::ATTRBYTES_MAX_TYPE`.
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   accessing `Storage`, `Filesystem` and `File` implementations for any storage.
 - Added `Filesystem::mount_or_else` function ([#57][])
 - Marked `Path::is_empty`, `Path::from_bytes_with_nul`, `Path::from_cstr`, `Path::from_cstr_unchecked`, `Path::as_str_ref_with_trailing_nul`, `Path::as_str`, and `PathBuf::new` as `const`.
+- Made `fs::FileOpenFlags` public and added `From<fs::FileOpenFlags>` for `fs::OpenOptions`.
 
 ### Fixed
 
@@ -32,11 +33,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Change `Error` enum to a struct with associated constants.
   - Remove `Error::Success` and enforce negative values for `Error`.
 - Replace `Path::exists` with `Filesystem::exists`
+- Replace `DynFilesystem::open_file_with_options_and_then{,unit}` with `DynFilesystem::open_file_with_flags_and_then{,unit}` using `FileOpenFlags` instead of `OpenOptionsCallback`
 
 ### Removed
 
 - Removed `Path::from_bytes_with_nul_unchecked`.  Use `CStr::from_bytes_with_nul_unchecked` and `Path::from_cstr_unchecked` instead.
 - Removed `From<littlefs2::path::Error> for littlefs2::io::Error`.
+- Removed `object_safe::OpenOptionsCallback`.
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,30 @@
+[workspace]
+members = ["core"]
+
+[workspace.package]
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/trussed-dev/littlefs2"
+
 [package]
 name = "littlefs2"
 description = "Idiomatic Rust API for littlefs"
 version = "0.4.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "Brandon Edens <brandonedens@gmail.com>", "The Trussed developers"]
-edition = "2021"
-license = "Apache-2.0 OR MIT"
 readme = "README.md"
 categories = ["embedded", "filesystem", "no-std"]
-repository = "https://github.com/trussed-dev/littlefs2"
 documentation = "https://docs.rs/littlefs2"
 
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
 [dependencies]
-bitflags = "1"
 delog = "0.1.0"
 generic-array = "0.14"
 heapless = "0.7"
+littlefs2-core = { version = "0.1", path = "core" }
 littlefs2-sys = "0.2"
-
-[dependencies.serde]
-version = "1"
-default-features = false
-features = ["derive"]
-optional = true
 
 [dev-dependencies]
 ssmarshal = "1"
@@ -31,7 +34,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 [features]
 default = ["dir-entry-path", "serde"]
 # use experimental closure-based API
-dir-entry-path = []
+dir-entry-path = ["littlefs2-core/dir-entry-path"]
+serde = ["littlefs2-core/serde"]
 # enable assertions in backend C code
 ll-assertions = ["littlefs2-sys/assertions"]
 # enable trace in backend C code

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ We follow [`std::fs`][std-fs] as much as reasonable.
 
 The low-level bindings are provided by the [littlefs2-sys][littlefs2-sys] library.
 
+The core types that are independent of a specific implementation version are provided by the `littlefs2-core` crate, see the [`core`](./core) directory.  These types are re-exported from the `littlefs2` crate too.
+
 Upstream release: [v2.2.1][upstream-release]
 
 [geky]: https://github.com/geky

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+Initial release with the core types from `littlefs2`.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 
 [dependencies]
 bitflags = "2.6.0"
-generic-array = "0.14"
 heapless = "0.7"
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "littlefs2-core"
+version = "0.1.0"
+authors = ["The Trussed developers"]
+description = "Core types for the littlefs2 crate"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+bitflags = "2.6.0"
+generic-array = "0.14"
+heapless = "0.7"
+serde = { version = "1", default-features = false, features = ["derive"], optional = true }
+
+[features]
+dir-entry-path = []
+serde = ["dep:serde"]

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -1,0 +1,5 @@
+pub const PATH_MAX: usize = 255;
+pub const PATH_MAX_PLUS_ONE: usize = PATH_MAX + 1;
+pub const ATTRBYTES_MAX: u32 = 1_022;
+#[allow(non_camel_case_types)]
+pub type ATTRBYTES_MAX_TYPE = generic_array::typenum::consts::U1022;

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -1,5 +1,3 @@
 pub const PATH_MAX: usize = 255;
 pub const PATH_MAX_PLUS_ONE: usize = PATH_MAX + 1;
 pub const ATTRBYTES_MAX: u32 = 1_022;
-#[allow(non_camel_case_types)]
-pub type ATTRBYTES_MAX_TYPE = generic_array::typenum::consts::U1022;

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -1,3 +1,0 @@
-pub const PATH_MAX: usize = 255;
-pub const PATH_MAX_PLUS_ONE: usize = PATH_MAX + 1;
-pub const ATTRBYTES_MAX: u32 = 1_022;

--- a/core/src/fs.rs
+++ b/core/src/fs.rs
@@ -1,0 +1,183 @@
+use core::cmp;
+
+use bitflags::bitflags;
+
+use crate::path::{Path, PathBuf};
+
+pub type Bytes<SIZE> = generic_array::GenericArray<u8, SIZE>;
+
+bitflags! {
+    /// Definition of file open flags which can be mixed and matched as appropriate. These definitions
+    /// are reminiscent of the ones defined by POSIX.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct FileOpenFlags: i32 {
+        /// Open file in read only mode.
+        const READ = 0x1;
+        /// Open file in write only mode.
+        const WRITE = 0x2;
+        /// Open file for reading and writing.
+        const READWRITE = Self::READ.bits() | Self::WRITE.bits();
+        /// Create the file if it does not exist.
+        const CREATE = 0x0100;
+        /// Fail if creating a file that already exists.
+        /// TODO: Good name for this
+        const EXCL = 0x0200;
+        /// Truncate the file if it already exists.
+        const TRUNCATE = 0x0400;
+        /// Open the file in append only mode.
+        const APPEND = 0x0800;
+    }
+}
+
+/// Regular file vs directory
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum FileType {
+    File,
+    Dir,
+}
+
+impl FileType {
+    pub fn is_dir(&self) -> bool {
+        *self == FileType::Dir
+    }
+
+    pub fn is_file(&self) -> bool {
+        *self == FileType::File
+    }
+}
+
+/// File type (regular vs directory) and size of a file.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Metadata {
+    file_type: FileType,
+    size: usize,
+}
+
+impl Metadata {
+    pub fn new(file_type: FileType, size: usize) -> Self {
+        Self { file_type, size }
+    }
+
+    pub fn file_type(&self) -> FileType {
+        self.file_type
+    }
+
+    pub fn is_dir(&self) -> bool {
+        self.file_type().is_dir()
+    }
+
+    pub fn is_file(&self) -> bool {
+        self.file_type().is_file()
+    }
+
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Custom user attribute that can be set on files and directories.
+///
+/// Consists of an numerical identifier between 0 and 255, and arbitrary
+/// binary data up to size `ATTRBYTES_MAX`.
+///
+/// Use [`Filesystem::attribute`](struct.Filesystem.html#method.attribute),
+/// [`Filesystem::set_attribute`](struct.Filesystem.html#method.set_attribute), and
+/// [`Filesystem::clear_attribute`](struct.Filesystem.html#method.clear_attribute).
+pub struct Attribute {
+    id: u8,
+    pub data: Bytes<crate::consts::ATTRBYTES_MAX_TYPE>,
+    pub size: usize,
+}
+
+impl Attribute {
+    pub fn new(id: u8) -> Self {
+        Attribute {
+            id,
+            data: Default::default(),
+            size: 0,
+        }
+    }
+
+    pub fn id(&self) -> u8 {
+        self.id
+    }
+
+    pub fn data(&self) -> &[u8] {
+        let attr_max = crate::consts::ATTRBYTES_MAX as _;
+        let len = cmp::min(attr_max, self.size);
+        &self.data[..len]
+    }
+
+    pub fn set_data(&mut self, data: &[u8]) -> &mut Self {
+        let attr_max = crate::consts::ATTRBYTES_MAX as _;
+        let len = cmp::min(attr_max, data.len());
+        self.data[..len].copy_from_slice(&data[..len]);
+        self.size = len;
+        for entry in self.data[len..].iter_mut() {
+            *entry = 0;
+        }
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DirEntry {
+    file_name: PathBuf,
+    metadata: Metadata,
+    #[cfg(feature = "dir-entry-path")]
+    path: PathBuf,
+}
+
+impl DirEntry {
+    pub fn new(
+        file_name: PathBuf,
+        metadata: Metadata,
+        #[cfg(feature = "dir-entry-path")] path: PathBuf,
+    ) -> Self {
+        Self {
+            file_name,
+            metadata,
+            #[cfg(feature = "dir-entry-path")]
+            path,
+        }
+    }
+
+    // Returns the metadata for the file that this entry points at.
+    pub fn metadata(&self) -> Metadata {
+        self.metadata.clone()
+    }
+
+    // Returns the file type for the file that this entry points at.
+    pub fn file_type(&self) -> FileType {
+        self.metadata.file_type
+    }
+
+    // Returns the bare file name of this directory entry without any other leading path component.
+    pub fn file_name(&self) -> &Path {
+        &self.file_name
+    }
+
+    /// Returns the full path to the file that this entry represents.
+    ///
+    /// The full path is created by joining the original path to read_dir with the filename of this entry.
+    #[cfg(feature = "dir-entry-path")]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[cfg(feature = "dir-entry-path")]
+    #[doc(hidden)]
+    // This is used in `crypto-service` to "namespace" paths
+    // by mutating a DirEntry in-place.
+    pub unsafe fn path_buf_mut(&mut self) -> &mut PathBuf {
+        &mut self.path
+    }
+}

--- a/core/src/fs.rs
+++ b/core/src/fs.rs
@@ -90,16 +90,18 @@ impl Metadata {
 /// [`Filesystem::clear_attribute`](struct.Filesystem.html#method.clear_attribute).
 pub struct Attribute {
     id: u8,
-    data: [u8; crate::consts::ATTRBYTES_MAX as _],
+    data: [u8; Attribute::MAX_SIZE as _],
     // invariant: size <= data.len()
     size: usize,
 }
 
 impl Attribute {
+    pub const MAX_SIZE: u32 = 1_022;
+
     pub fn new(id: u8) -> Self {
         Attribute {
             id,
-            data: [0; crate::consts::ATTRBYTES_MAX as _],
+            data: [0; Self::MAX_SIZE as _],
             size: 0,
         }
     }
@@ -109,7 +111,7 @@ impl Attribute {
     }
 
     pub fn data(&self) -> &[u8] {
-        let attr_max = crate::consts::ATTRBYTES_MAX as _;
+        let attr_max = Self::MAX_SIZE as _;
         let len = cmp::min(attr_max, self.size);
         &self.data[..len]
     }
@@ -119,7 +121,7 @@ impl Attribute {
     }
 
     pub fn set_data(&mut self, data: &[u8]) -> &mut Self {
-        let attr_max = crate::consts::ATTRBYTES_MAX as _;
+        let attr_max = Self::MAX_SIZE as _;
         let len = cmp::min(attr_max, data.len());
         self.data[..len].copy_from_slice(&data[..len]);
         self.size = len;

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -1,13 +1,9 @@
 //! Traits and types for core I/O functionality.
 
-pub mod prelude;
-
 use core::{
     ffi::c_int,
     fmt::{self, Debug, Formatter},
 };
-
-use littlefs2_sys as ll;
 
 /// The `Read` trait allows for reading bytes from a file.
 pub trait Read {
@@ -70,7 +66,7 @@ pub enum SeekFrom {
 }
 
 impl SeekFrom {
-    pub(crate) fn off(self) -> i32 {
+    pub fn off(self) -> i32 {
         match self {
             SeekFrom::Start(u) => u as i32,
             SeekFrom::End(i) => i,
@@ -78,7 +74,7 @@ impl SeekFrom {
         }
     }
 
-    pub(crate) fn whence(self) -> i32 {
+    pub fn whence(self) -> i32 {
         match self {
             SeekFrom::Start(_) => 0,
             SeekFrom::End(_) => 2,
@@ -88,7 +84,7 @@ impl SeekFrom {
 }
 
 /// Enumeration of possible methods to seek within an file that was just opened
-/// Used in the [`read_chunk`](crate::fs::Filesystem::read_chunk) and [`write_chunk`](crate::fs::Filesystem::write_chunk) methods,
+/// Used in the `read_chunk` and `write_chunk` methods,
 /// Where [`SeekFrom::Current`] would not make sense.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum OpenSeekFrom {
@@ -122,8 +118,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// Specific error codes are available as associated constants of this type.
 ///
 /// ```
-/// # use littlefs2::io::Error;
-///
+/// # use littlefs2_core::Error;
 /// assert_eq!(Error::IO.code(), -5);
 /// assert_eq!(Error::new(-5), Some(Error::IO));
 /// ```
@@ -134,46 +129,46 @@ pub struct Error {
 
 impl Error {
     /// Input / output error occurred.
-    pub const IO: Self = Self::new_const(ll::lfs_error_LFS_ERR_IO);
+    pub const IO: Self = Self::new_const(-5);
 
     /// File or filesystem was corrupt.
-    pub const CORRUPTION: Self = Self::new_const(ll::lfs_error_LFS_ERR_CORRUPT);
+    pub const CORRUPTION: Self = Self::new_const(-84);
 
     /// No entry found with that name.
-    pub const NO_SUCH_ENTRY: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOENT);
+    pub const NO_SUCH_ENTRY: Self = Self::new_const(-2);
 
     /// File or directory already exists.
-    pub const ENTRY_ALREADY_EXISTED: Self = Self::new_const(ll::lfs_error_LFS_ERR_EXIST);
+    pub const ENTRY_ALREADY_EXISTED: Self = Self::new_const(-17);
 
     /// Path name is not a directory.
-    pub const PATH_NOT_DIR: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOTDIR);
+    pub const PATH_NOT_DIR: Self = Self::new_const(-20);
 
     /// Path specification is to a directory.
-    pub const PATH_IS_DIR: Self = Self::new_const(ll::lfs_error_LFS_ERR_ISDIR);
+    pub const PATH_IS_DIR: Self = Self::new_const(-21);
 
     /// Directory was not empty.
-    pub const DIR_NOT_EMPTY: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOTEMPTY);
+    pub const DIR_NOT_EMPTY: Self = Self::new_const(-39);
 
     /// Bad file descriptor.
-    pub const BAD_FILE_DESCRIPTOR: Self = Self::new_const(ll::lfs_error_LFS_ERR_BADF);
+    pub const BAD_FILE_DESCRIPTOR: Self = Self::new_const(-9);
 
     /// File is too big.
-    pub const FILE_TOO_BIG: Self = Self::new_const(ll::lfs_error_LFS_ERR_FBIG);
+    pub const FILE_TOO_BIG: Self = Self::new_const(-27);
 
     /// Incorrect value specified to function.
-    pub const INVALID: Self = Self::new_const(ll::lfs_error_LFS_ERR_INVAL);
+    pub const INVALID: Self = Self::new_const(-22);
 
     /// No space left available for operation.
-    pub const NO_SPACE: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOSPC);
+    pub const NO_SPACE: Self = Self::new_const(-28);
 
     /// No memory available for completing request.
-    pub const NO_MEMORY: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOMEM);
+    pub const NO_MEMORY: Self = Self::new_const(-12);
 
     /// No attribute or data available
-    pub const NO_ATTRIBUTE: Self = Self::new_const(ll::lfs_error_LFS_ERR_NOATTR);
+    pub const NO_ATTRIBUTE: Self = Self::new_const(-61);
 
     /// Filename too long
-    pub const FILENAME_TOO_LONG: Self = Self::new_const(ll::lfs_error_LFS_ERR_NAMETOOLONG);
+    pub const FILENAME_TOO_LONG: Self = Self::new_const(-36);
 
     /// Construct an `Error` from an error code.
     ///
@@ -225,8 +220,7 @@ impl Error {
 /// Prints the numeric error code and the name of the error (if known).
 ///
 /// ```
-/// # use littlefs2::io::Error;
-///
+/// # use littlefs2_core::Error;
 /// assert_eq!(
 ///     &format!("{:?}", Error::IO),
 ///     "Error { code: -5, kind: Some(\"Io\") }",
@@ -249,19 +243,5 @@ impl Debug for Error {
 impl From<Error> for c_int {
     fn from(error: Error) -> Self {
         error.code
-    }
-}
-
-pub fn error_code_from<T>(result: Result<T>) -> ll::lfs_error {
-    result
-        .map(|_| ll::lfs_error_LFS_ERR_OK)
-        .unwrap_or_else(From::from)
-}
-
-pub fn result_from<T>(return_value: T, error_code: ll::lfs_error) -> Result<T> {
-    if let Some(error) = Error::new(error_code) {
-        Err(error)
-    } else {
-        Ok(return_value)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,63 @@
+#![no_std]
+
+//! Core types for the [`littlefs2`][] crate.
+//!
+//! See the documentation for [`littlefs2`][] for more information.
+//!
+//! [`littlefs2`]: https://docs.rs/littlefs2
+
+mod consts;
+mod fs;
+mod io;
+mod object_safe;
+mod path;
+
+pub use consts::{ATTRBYTES_MAX, ATTRBYTES_MAX_TYPE, PATH_MAX, PATH_MAX_PLUS_ONE};
+pub use fs::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
+pub use io::{Error, OpenSeekFrom, Read, Result, Seek, SeekFrom, Write};
+pub use object_safe::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate};
+pub use path::{Ancestors, Iter, Path, PathBuf, PathError};
+
+/// Creates a path from a string without a trailing null.
+///
+/// Panics and causes a compiler error if the string contains null bytes or non-ascii characters.
+///
+/// # Examples
+///
+/// ```
+/// use littlefs2_core::{path, Path};
+///
+/// const HOME: &Path = path!("/home");
+/// let root = path!("/");
+/// ```
+///
+/// Illegal values:
+///
+/// ```compile_fail
+/// # use littlefs2_core::{path, Path};
+/// const WITH_NULL: &Path = path!("/h\0me");  // does not compile
+/// ```
+///
+/// ```compile_fail
+/// # use littlefs2_core::{path, Path};
+/// const WITH_UTF8: &Path = path!("/höme");  // does not compile
+/// ```
+///
+/// The macro enforces const evaluation so that compilation fails for illegal values even if the
+/// macro is not used in a const context:
+///
+/// ```compile_fail
+/// # use littlefs2_core::path;
+/// let path = path!("te\0st");  // does not compile
+/// ```
+#[macro_export]
+macro_rules! path {
+    ($path:literal) => {{
+        const _PATH: &$crate::Path =
+            match $crate::Path::from_str_with_nul(::core::concat!($path, "\0")) {
+                Ok(path) => path,
+                Err(_) => panic!("invalid littlefs2 path"),
+            };
+        _PATH
+    }};
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,7 +12,7 @@ mod io;
 mod object_safe;
 mod path;
 
-pub use consts::{ATTRBYTES_MAX, ATTRBYTES_MAX_TYPE, PATH_MAX, PATH_MAX_PLUS_ONE};
+pub use consts::{ATTRBYTES_MAX, PATH_MAX, PATH_MAX_PLUS_ONE};
 pub use fs::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
 pub use io::{Error, OpenSeekFrom, Read, Result, Seek, SeekFrom, Write};
 pub use object_safe::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -6,13 +6,11 @@
 //!
 //! [`littlefs2`]: https://docs.rs/littlefs2
 
-mod consts;
 mod fs;
 mod io;
 mod object_safe;
 mod path;
 
-pub use consts::{ATTRBYTES_MAX, PATH_MAX, PATH_MAX_PLUS_ONE};
 pub use fs::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
 pub use io::{Error, OpenSeekFrom, Read, Result, Seek, SeekFrom, Write};
 pub use object_safe::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate};

--- a/core/src/object_safe.rs
+++ b/core/src/object_safe.rs
@@ -1,0 +1,151 @@
+use heapless::Vec;
+
+use crate::{
+    fs::{Attribute, DirEntry, FileOpenFlags, Metadata},
+    io::{Error, OpenSeekFrom, Read, Result, Seek, Write},
+    path::Path,
+};
+
+// Make sure that the traits actually are object safe.
+const _: Option<&dyn DynFile> = None;
+const _: Option<&dyn DynFilesystem> = None;
+
+pub type DirEntriesCallback<'a, R = ()> =
+    &'a mut dyn FnMut(&mut dyn Iterator<Item = Result<DirEntry>>) -> Result<R>;
+pub type FileCallback<'a, R = ()> = &'a mut dyn FnMut(&dyn DynFile) -> Result<R>;
+pub type Predicate<'a> = &'a dyn Fn(&DirEntry) -> bool;
+
+/// Object-safe trait for files.
+///
+/// The methods for opening files cannot be implemented in this trait.  Use these methods instead:
+/// - [`DynFilesystem::create_file_and_then`](trait.DynFilesystem.html#method.create_file_and_then)
+/// - [`DynFilesystem::open_file_and_then`](trait.DynFilesystem.html#method.open_file_and_then)
+/// - [`DynFilesystem::open_file_with_options_and_then`](trait.DynFilesystem.html#method.open_file_with_options_and_then)
+pub trait DynFile: Read + Seek + Write {
+    fn sync(&self) -> Result<()>;
+    fn len(&self) -> Result<usize>;
+    fn is_empty(&self) -> Result<bool>;
+    fn set_len(&self, size: usize) -> Result<()>;
+}
+
+impl dyn DynFile + '_ {
+    pub fn read_to_end<const N: usize>(&self, buf: &mut Vec<u8, N>) -> Result<usize> {
+        let had = buf.len();
+        buf.resize_default(buf.capacity()).unwrap();
+        let read = self.read(&mut buf[had..])?;
+        buf.truncate(had + read);
+        Ok(read)
+    }
+}
+
+/// Object-safe trait for filesystems.
+///
+/// The following methods cannot support generic return types in the callbacks:
+/// - [`DynFilesystem::create_file_and_then_unit`][]
+/// - [`DynFilesystem::open_file_and_then_unit`][]
+/// - [`DynFilesystem::open_file_with_flags_and_then_unit`][]
+/// - [`DynFilesystem::read_dir_and_then_unit`][]
+///
+/// Use these helper functions instead:
+/// - [`DynFilesystem::create_file_and_then`](#method.create_file_and_then)
+/// - [`DynFilesystem::open_file_and_then`](#method.open_file_and_then)
+/// - [`DynFilesystem::open_file_with_flags_and_then`](#method.open_file_with_flags_and_then)
+/// - [`DynFilesystem::read_dir_and_then`](#method.read_dir_and_then)
+pub trait DynFilesystem {
+    fn total_blocks(&self) -> usize;
+    fn total_space(&self) -> usize;
+    fn available_blocks(&self) -> Result<usize>;
+    fn available_space(&self) -> Result<usize>;
+    fn remove(&self, path: &Path) -> Result<()>;
+    fn remove_dir(&self, path: &Path) -> Result<()>;
+    #[cfg(feature = "dir-entry-path")]
+    fn remove_dir_all(&self, path: &Path) -> Result<()>;
+    #[cfg(feature = "dir-entry-path")]
+    fn remove_dir_all_where(&self, path: &Path, predicate: Predicate<'_>) -> Result<usize>;
+    fn rename(&self, from: &Path, to: &Path) -> Result<()>;
+    fn exists(&self, path: &Path) -> bool;
+    fn metadata(&self, path: &Path) -> Result<Metadata>;
+    fn create_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
+    fn open_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
+    fn open_file_with_flags_and_then_unit(
+        &self,
+        flags: FileOpenFlags,
+        path: &Path,
+        f: FileCallback<'_>,
+    ) -> Result<()>;
+    fn attribute(&self, path: &Path, id: u8) -> Result<Option<Attribute>>;
+    fn remove_attribute(&self, path: &Path, id: u8) -> Result<()>;
+    fn set_attribute(&self, path: &Path, attribute: &Attribute) -> Result<()>;
+    fn read_dir_and_then_unit(&self, path: &Path, f: DirEntriesCallback<'_>) -> Result<()>;
+    fn create_dir(&self, path: &Path) -> Result<()>;
+    fn create_dir_all(&self, path: &Path) -> Result<()>;
+    fn write(&self, path: &Path, contents: &[u8]) -> Result<()>;
+    fn write_chunk(&self, path: &Path, contents: &[u8], pos: OpenSeekFrom) -> Result<()>;
+}
+
+impl dyn DynFilesystem + '_ {
+    pub fn read<const N: usize>(&self, path: &Path) -> Result<Vec<u8, N>> {
+        let mut contents = Vec::new();
+        self.open_file_and_then(path, &mut |file| {
+            file.read_to_end(&mut contents)?;
+            Ok(())
+        })?;
+        Ok(contents)
+    }
+
+    pub fn read_chunk<const N: usize>(
+        &self,
+        path: &Path,
+        pos: OpenSeekFrom,
+    ) -> Result<(Vec<u8, N>, usize)> {
+        let mut contents = Vec::new();
+        let file_len = self.open_file_and_then(path, &mut |file| {
+            file.seek(pos.into())?;
+            let read_n = file.read(&mut contents)?;
+            contents.truncate(read_n);
+            file.len()
+        })?;
+        Ok((contents, file_len))
+    }
+
+    pub fn create_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
+        let mut result = Err(Error::IO);
+        self.create_file_and_then_unit(path, &mut |file| {
+            result = Ok(f(file)?);
+            Ok(())
+        })?;
+        result
+    }
+
+    pub fn open_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
+        let mut result = Err(Error::IO);
+        self.open_file_and_then_unit(path, &mut |file| {
+            result = Ok(f(file)?);
+            Ok(())
+        })?;
+        result
+    }
+
+    pub fn open_file_with_flags_and_then<R>(
+        &self,
+        flags: FileOpenFlags,
+        path: &Path,
+        f: FileCallback<'_, R>,
+    ) -> Result<R> {
+        let mut result = Err(Error::IO);
+        self.open_file_with_flags_and_then_unit(flags, path, &mut |file| {
+            result = Ok(f(file)?);
+            Ok(())
+        })?;
+        result
+    }
+
+    pub fn read_dir_and_then<R>(&self, path: &Path, f: DirEntriesCallback<'_, R>) -> Result<R> {
+        let mut result = Err(Error::IO);
+        self.read_dir_and_then_unit(path, &mut |entries| {
+            result = Ok(f(entries)?);
+            Ok(())
+        })?;
+        result
+    }
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,8 +3,9 @@
 /// Re-export of `typenum::consts`.
 pub use generic_array::typenum::consts::*;
 
-pub use littlefs2_core::{ATTRBYTES_MAX, PATH_MAX, PATH_MAX_PLUS_ONE};
-
+pub const PATH_MAX: usize = littlefs2_core::PathBuf::MAX_SIZE;
+pub const PATH_MAX_PLUS_ONE: usize = littlefs2_core::PathBuf::MAX_SIZE_PLUS_ONE;
 pub const FILENAME_MAX_PLUS_ONE: u32 = 255 + 1;
 pub const FILEBYTES_MAX: u32 = crate::ll::LFS_FILE_MAX as _;
+pub const ATTRBYTES_MAX: u32 = littlefs2_core::Attribute::MAX_SIZE;
 pub const LOOKAHEADWORDS_SIZE: u32 = 16;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,12 +3,8 @@
 /// Re-export of `typenum::consts`.
 pub use generic_array::typenum::consts::*;
 
+pub use littlefs2_core::{ATTRBYTES_MAX, ATTRBYTES_MAX_TYPE, PATH_MAX, PATH_MAX_PLUS_ONE};
+
 pub const FILENAME_MAX_PLUS_ONE: u32 = 255 + 1;
-// pub type PATH_DEFAULT_MAX = generic_array::typenum::consts::U255;
-// pub const PATH_MAX: u32 = 255;
-pub const PATH_MAX: usize = 255;
-pub const PATH_MAX_PLUS_ONE: usize = PATH_MAX + 1;
 pub const FILEBYTES_MAX: u32 = crate::ll::LFS_FILE_MAX as _;
-pub const ATTRBYTES_MAX: u32 = 1_022;
-pub type ATTRBYTES_MAX_TYPE = U1022;
 pub const LOOKAHEADWORDS_SIZE: u32 = 16;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,7 +3,7 @@
 /// Re-export of `typenum::consts`.
 pub use generic_array::typenum::consts::*;
 
-pub use littlefs2_core::{ATTRBYTES_MAX, ATTRBYTES_MAX_TYPE, PATH_MAX, PATH_MAX_PLUS_ONE};
+pub use littlefs2_core::{ATTRBYTES_MAX, PATH_MAX, PATH_MAX_PLUS_ONE};
 
 pub const FILENAME_MAX_PLUS_ONE: u32 = 255 + 1;
 pub const FILEBYTES_MAX: u32 = crate::ll::LFS_FILE_MAX as _;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -5,7 +5,7 @@ use core::ptr::addr_of;
 use core::ptr::addr_of_mut;
 use core::{
     cell::{RefCell, UnsafeCell},
-    cmp, mem, slice,
+    mem, slice,
 };
 use generic_array::typenum::marker_traits::Unsigned;
 use littlefs2_sys as ll;
@@ -425,13 +425,13 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
                 &mut self.alloc.borrow_mut().state,
                 path.as_ptr(),
                 id,
-                &mut attribute.data as *mut _ as *mut c_void,
+                attribute.buffer_mut() as *mut _ as *mut c_void,
                 attr_max,
             )
         };
 
         if return_code >= 0 {
-            attribute.size = cmp::min(attr_max, return_code as u32) as usize;
+            attribute.set_size(return_code as usize);
             return Ok(Some(attribute));
         }
         if return_code == ll::lfs_error_LFS_ERR_NOATTR {
@@ -457,8 +457,8 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
                 &mut self.alloc.borrow_mut().state,
                 path.as_ptr(),
                 attribute.id(),
-                &attribute.data as *const _ as *const c_void,
-                attribute.size as u32,
+                attribute.data() as *const _ as *const c_void,
+                attribute.size() as u32,
             )
         };
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -613,7 +613,7 @@ impl Attribute {
 bitflags! {
     /// Definition of file open flags which can be mixed and matched as appropriate. These definitions
     /// are reminiscent of the ones defined by POSIX.
-    struct FileOpenFlags: u32 {
+    pub struct FileOpenFlags: i32 {
         /// Open file in read only mode.
         const READ = 0x1;
         /// Open file in write only mode.
@@ -859,7 +859,7 @@ impl OpenOptions {
             &mut fs.alloc.borrow_mut().state,
             addr_of_mut!(alloc.state),
             path.as_ptr(),
-            self.0.bits() as i32,
+            self.0.bits(),
             addr_of!(alloc.config),
         );
 
@@ -947,6 +947,12 @@ impl OpenOptions {
             self.0.remove(FileOpenFlags::TRUNCATE)
         };
         self
+    }
+}
+
+impl From<FileOpenFlags> for OpenOptions {
+    fn from(flags: FileOpenFlags) -> Self {
+        Self(flags)
     }
 }
 

--- a/src/io/prelude.rs
+++ b/src/io/prelude.rs
@@ -1,3 +1,0 @@
-//! Export of the Read, Write and Seek traits for ease of use.
-
-pub use super::{Read, Seek, SeekFrom, Write};

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -1,40 +1,20 @@
 //! Object-safe traits for [`File`][], [`Filesystem`][] and [`Storage`][].
 
 use generic_array::typenum::Unsigned as _;
-use heapless::Vec;
 
 use crate::{
     driver::Storage,
-    fs::{Attribute, DirEntry, File, FileOpenFlags, Filesystem, Metadata},
-    io::{Error, OpenSeekFrom, Read, Result, Seek, Write},
+    fs::{Attribute, File, FileOpenFlags, Filesystem, Metadata},
+    io::{Error, OpenSeekFrom, Result},
     path::Path,
 };
 
+pub use littlefs2_core::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate};
+
 // Make sure that the traits actually are object safe.
-const _: Option<&dyn DynFile> = None;
-const _: Option<&dyn DynFilesystem> = None;
 const _: Option<&dyn DynStorage> = None;
 
-pub type DirEntriesCallback<'a, R = ()> =
-    &'a mut dyn FnMut(&mut dyn Iterator<Item = Result<DirEntry>>) -> Result<R>;
-pub type FileCallback<'a, R = ()> = &'a mut dyn FnMut(&dyn DynFile) -> Result<R>;
 pub type FilesystemCallback<'a, R = ()> = &'a mut dyn FnMut(&dyn DynFilesystem) -> Result<R>;
-pub type Predicate<'a> = &'a dyn Fn(&DirEntry) -> bool;
-
-/// Object-safe trait for [`File`][].
-///
-/// The methods for opening files cannot be implemented in this trait.  Use these methods instead:
-/// - [`DynFilesystem::create_file_and_then`](trait.DynFilesystem.html#method.create_file_and_then)
-/// - [`DynFilesystem::open_file_and_then`](trait.DynFilesystem.html#method.open_file_and_then)
-/// - [`DynFilesystem::open_file_with_options_and_then`](trait.DynFilesystem.html#method.open_file_with_options_and_then)
-///
-/// All other methods are mirrored directly.  See the documentation for [`File`][] for more information.
-pub trait DynFile: Read + Seek + Write {
-    fn sync(&self) -> Result<()>;
-    fn len(&self) -> Result<usize>;
-    fn is_empty(&self) -> Result<bool>;
-    fn set_len(&self, size: usize) -> Result<()>;
-}
 
 impl<S: Storage> DynFile for File<'_, '_, S> {
     fn sync(&self) -> Result<()> {
@@ -52,68 +32,6 @@ impl<S: Storage> DynFile for File<'_, '_, S> {
     fn set_len(&self, size: usize) -> Result<()> {
         File::set_len(self, size)
     }
-}
-
-impl dyn DynFile + '_ {
-    pub fn read_to_end<const N: usize>(&self, buf: &mut Vec<u8, N>) -> Result<usize> {
-        let had = buf.len();
-        buf.resize_default(buf.capacity()).unwrap();
-        let read = self.read(&mut buf[had..])?;
-        buf.truncate(had + read);
-        Ok(read)
-    }
-}
-
-/// Object-safe trait for [`Filesystem`][].
-///
-/// The following methods are implemented in [`DynStorage`][] instead:
-/// - [`DynStorage::format`][]
-/// - [`DynStorage::is_mountable`][]
-/// - [`DynStorage::mount_and_then`](trait.DynStorage.html#method.mount_and_then)
-///
-/// The following methods cannot support generic return types in the callbacks:
-/// - [`DynFilesystem::create_file_and_then_unit`][]
-/// - [`DynFilesystem::open_file_and_then_unit`][]
-/// - [`DynFilesystem::open_file_with_flags_and_then_unit`][]
-/// - [`DynFilesystem::read_dir_and_then_unit`][]
-///
-/// Use these helper functions instead:
-/// - [`DynFilesystem::create_file_and_then`](#method.create_file_and_then)
-/// - [`DynFilesystem::open_file_and_then`](#method.open_file_and_then)
-/// - [`DynFilesystem::open_file_with_options_and_then`](#method.open_file_with_options_and_then)
-/// - [`DynFilesystem::read_dir_and_then`](#method.read_dir_and_then)
-///
-/// All other methods are mirrored directly.  See the documentation for [`Filesystem`][] for more information.
-pub trait DynFilesystem {
-    fn total_blocks(&self) -> usize;
-    fn total_space(&self) -> usize;
-    fn available_blocks(&self) -> Result<usize>;
-    fn available_space(&self) -> Result<usize>;
-    fn remove(&self, path: &Path) -> Result<()>;
-    fn remove_dir(&self, path: &Path) -> Result<()>;
-    #[cfg(feature = "dir-entry-path")]
-    fn remove_dir_all(&self, path: &Path) -> Result<()>;
-    #[cfg(feature = "dir-entry-path")]
-    fn remove_dir_all_where(&self, path: &Path, predicate: Predicate<'_>) -> Result<usize>;
-    fn rename(&self, from: &Path, to: &Path) -> Result<()>;
-    fn exists(&self, path: &Path) -> bool;
-    fn metadata(&self, path: &Path) -> Result<Metadata>;
-    fn create_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
-    fn open_file_and_then_unit(&self, path: &Path, f: FileCallback<'_>) -> Result<()>;
-    fn open_file_with_flags_and_then_unit(
-        &self,
-        flags: FileOpenFlags,
-        path: &Path,
-        f: FileCallback<'_>,
-    ) -> Result<()>;
-    fn attribute(&self, path: &Path, id: u8) -> Result<Option<Attribute>>;
-    fn remove_attribute(&self, path: &Path, id: u8) -> Result<()>;
-    fn set_attribute(&self, path: &Path, attribute: &Attribute) -> Result<()>;
-    fn read_dir_and_then_unit(&self, path: &Path, f: DirEntriesCallback<'_>) -> Result<()>;
-    fn create_dir(&self, path: &Path) -> Result<()>;
-    fn create_dir_all(&self, path: &Path) -> Result<()>;
-    fn write(&self, path: &Path, contents: &[u8]) -> Result<()>;
-    fn write_chunk(&self, path: &Path, contents: &[u8], pos: OpenSeekFrom) -> Result<()>;
 }
 
 impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
@@ -218,73 +136,6 @@ impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
 
     fn write_chunk(&self, path: &Path, contents: &[u8], pos: OpenSeekFrom) -> Result<()> {
         Filesystem::write_chunk(self, path, contents, pos)
-    }
-}
-
-impl dyn DynFilesystem + '_ {
-    pub fn read<const N: usize>(&self, path: &Path) -> Result<Vec<u8, N>> {
-        let mut contents = Vec::new();
-        self.open_file_and_then(path, &mut |file| {
-            file.read_to_end(&mut contents)?;
-            Ok(())
-        })?;
-        Ok(contents)
-    }
-
-    pub fn read_chunk<const N: usize>(
-        &self,
-        path: &Path,
-        pos: OpenSeekFrom,
-    ) -> Result<(Vec<u8, N>, usize)> {
-        let mut contents = Vec::new();
-        let file_len = self.open_file_and_then(path, &mut |file| {
-            file.seek(pos.into())?;
-            let read_n = file.read(&mut contents)?;
-            contents.truncate(read_n);
-            file.len()
-        })?;
-        Ok((contents, file_len))
-    }
-
-    pub fn create_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::IO);
-        self.create_file_and_then_unit(path, &mut |file| {
-            result = Ok(f(file)?);
-            Ok(())
-        })?;
-        result
-    }
-
-    pub fn open_file_and_then<R>(&self, path: &Path, f: FileCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::IO);
-        self.open_file_and_then_unit(path, &mut |file| {
-            result = Ok(f(file)?);
-            Ok(())
-        })?;
-        result
-    }
-
-    pub fn open_file_with_flags_and_then<R>(
-        &self,
-        flags: FileOpenFlags,
-        path: &Path,
-        f: FileCallback<'_, R>,
-    ) -> Result<R> {
-        let mut result = Err(Error::IO);
-        self.open_file_with_flags_and_then_unit(flags, path, &mut |file| {
-            result = Ok(f(file)?);
-            Ok(())
-        })?;
-        result
-    }
-
-    pub fn read_dir_and_then<R>(&self, path: &Path, f: DirEntriesCallback<'_, R>) -> Result<R> {
-        let mut result = Err(Error::IO);
-        self.read_dir_and_then_unit(path, &mut |entries| {
-            result = Ok(f(entries)?);
-            Ok(())
-        })?;
-        result
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,7 @@ use crate::{
     driver,
     fs::{Attribute, File, Filesystem},
     io::{Error, OpenSeekFrom, Read, Result, SeekFrom},
+    path,
 };
 
 ram_storage!(


### PR DESCRIPTION
This PR introduces a `littlefs2-core` crate that provides an interface that does not depend on a specific littlefs2 version.  The goal is to make applications using `littlefs2` easier to maintain as they no longer need to be updated if a `littlefs2` implementation detail is changed.

The API of `littlefs2` is mostly unaffected by this change as all moved items are re-exported under their old name.  Some changes are required to de-couple the moved types from the actual implementation.  See the changelog for details.

Contrary to the initial proposal in https://github.com/trussed-dev/littlefs2/issues/55, this does not move the `DynStorage` trait.  From my point of view, it is coupled too tightly to the actual storage implementation that could be subject to change.  Also, there is no real benefit of having it in the core crate as applications are not expected to use the storage directly.  If necessary, we can always add this in the future.

Before the core crate is released, we should consider removing the `dir-entry-path` feature (and just always including the path) and putting the `heapless` dependency behind a feature flag with potential support for other versions.  But I’d prefer to discuss that separately.

Fixes: https://github.com/trussed-dev/littlefs2/issues/55