### PR TITLE
Extend CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,20 @@ jobs:
       - name: Build
         run: cargo build --release --verbose
 
+      - name: Run clippy
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo clippy --all-features --all-targets -- --deny warnings
+
+      - name: Check code format
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo fmt -- --check
+
       - name: Run tests
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: >
           cargo test &&
           cargo test --release
 
-      - name: Build Documentation
-        run: cargo doc --no-deps
+      - name: Check documentation
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -2,7 +2,6 @@
 #![allow(non_camel_case_types)]
 
 use generic_array::ArrayLength;
-use littlefs2_sys as ll;
 
 use crate::io::Result;
 
@@ -93,45 +92,4 @@ pub trait Storage {
     fn erase(&mut self, off: usize, len: usize) -> Result<usize>;
     // /// Synchronize writes to the storage device.
     // fn sync(&mut self) -> Result<usize>;
-}
-
-// in the future, try to split the megatrait `Storage` into pieces
-// like this?
-mod future {
-    // content of "superblock"
-    pub trait DiskFormat {
-        // version, upper/lower half-word contain major/minor
-        // const DISK_FORMAT_VERSION: u32,
-
-        // block_size, block_count
-        const BLOCK_SIZE: usize;
-        const BLOCK_COUNT: usize;
-
-        // name_max, file_max, attr_max
-        type FILENAME_MAX_PLUS_ONE;
-        const FILEBYTES_MAX: usize = super::ll::LFS_FILE_MAX as _;
-        type ATTRBYTES_MAX;
-    }
-
-    pub trait Driver {
-        const READ_SIZE: usize;
-        const WRITE_SIZE: usize;
-
-        const BLOCK_SIZE: usize;
-        const BLOCK_COUNT: usize;
-
-        // fn read(&self, offset: usize, buf: &mut [u8]) -> Result<usize>;
-        // fn write(&mut self, offset: usize, data: &[u8]) -> Result<usize>;
-        // fn erase(&mut self, offset: usize, len: usize) -> Result<usize>;
-    }
-
-    pub trait MemoryUsage {
-        // TODO: this supposedly influences whether files are inlined or not. Clarify
-        type CACHE_SIZE;
-        type LOOKAHEADWORDS_SIZE;
-    }
-
-    pub trait RuntimeParameters {
-        const BLOCK_CYCLES: isize = -1;
-    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -474,7 +474,7 @@ fn test_iter_dirs() {
     let mut storage = RamStorage::new(&mut backend);
     Filesystem::format(&mut storage).unwrap();
     Filesystem::mount_and_then(&mut storage, |fs| {
-        fs.create_dir(path!("/tmp").into())?;
+        fs.create_dir(path!("/tmp"))?;
 
         // TODO: we might want "multi-open"
         fs.create_file_and_then(path!("/tmp/file.a"), |file| {


### PR DESCRIPTION
This patch adds clippy and rustfmt to the CI and fails the workflow if cargo doc shows a warning.