### PR TITLE
core: Use c_int where applicable

### DIFF
--- a/core/src/fs.rs
+++ b/core/src/fs.rs
@@ -1,4 +1,4 @@
-use core::cmp;
+use core::{cmp, ffi::c_int};
 
 use bitflags::bitflags;
 
@@ -8,7 +8,7 @@ bitflags! {
     /// Definition of file open flags which can be mixed and matched as appropriate. These definitions
     /// are reminiscent of the ones defined by POSIX.
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    pub struct FileOpenFlags: i32 {
+    pub struct FileOpenFlags: c_int {
         /// Open file in read only mode.
         const READ = 0x1;
         /// Open file in write only mode.

--- a/core/src/io.rs
+++ b/core/src/io.rs
@@ -74,7 +74,7 @@ impl SeekFrom {
         }
     }
 
-    pub fn whence(self) -> i32 {
+    pub fn whence(self) -> c_int {
         match self {
             SeekFrom::Start(_) => 0,
             SeekFrom::End(_) => 2,


### PR DESCRIPTION
This patch applies those changes from https://github.com/trussed-dev/littlefs2/pull/69 that affect the core crate.