### PR TITLE
Refactor attributes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Remove `Error::Success` and enforce negative values for `Error`.
 - Replace `Path::exists` with `Filesystem::exists`
 - Replace `DynFilesystem::open_file_with_options_and_then{,unit}` with `DynFilesystem::open_file_with_flags_and_then{,unit}` using `FileOpenFlags` instead of `OpenOptionsCallback`
+- Refactor attributes API:
+  - Change the `set_attribute` function in `DynFilesystem` and `Filesystem` to accept an ID and a slice instead of an `Attribute`.
+  - Add a buffer argument to the `attribute` function in `DynFilesystem` and `Filesystem` and return a slice of that buffer containing the read data.
+  - Change the `Attribute` struct to store a slice with the read data and the total size of the attribute on the filesystem.
 
 ### Removed
 

--- a/core/src/object_safe.rs
+++ b/core/src/object_safe.rs
@@ -73,9 +73,14 @@ pub trait DynFilesystem {
         path: &Path,
         f: FileCallback<'_>,
     ) -> Result<()>;
-    fn attribute(&self, path: &Path, id: u8) -> Result<Option<Attribute>>;
+    fn attribute<'a>(
+        &self,
+        path: &Path,
+        id: u8,
+        buffer: &'a mut [u8],
+    ) -> Result<Option<Attribute<'a>>>;
     fn remove_attribute(&self, path: &Path, id: u8) -> Result<()>;
-    fn set_attribute(&self, path: &Path, attribute: &Attribute) -> Result<()>;
+    fn set_attribute(&self, path: &Path, id: u8, data: &[u8]) -> Result<()>;
     fn read_dir_and_then_unit(&self, path: &Path, f: DirEntriesCallback<'_>) -> Result<()>;
     fn create_dir(&self, path: &Path) -> Result<()>;
     fn create_dir_all(&self, path: &Path) -> Result<()>;

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -106,16 +106,21 @@ impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
         )
     }
 
-    fn attribute(&self, path: &Path, id: u8) -> Result<Option<Attribute>> {
-        Filesystem::attribute(self, path, id)
+    fn attribute<'a>(
+        &self,
+        path: &Path,
+        id: u8,
+        buffer: &'a mut [u8],
+    ) -> Result<Option<Attribute<'a>>> {
+        Filesystem::attribute(self, path, id, buffer)
     }
 
     fn remove_attribute(&self, path: &Path, id: u8) -> Result<()> {
         Filesystem::remove_attribute(self, path, id)
     }
 
-    fn set_attribute(&self, path: &Path, attribute: &Attribute) -> Result<()> {
-        Filesystem::set_attribute(self, path, attribute)
+    fn set_attribute(&self, path: &Path, id: u8, data: &[u8]) -> Result<()> {
+        Filesystem::set_attribute(self, path, id, data)
     }
 
     fn read_dir_and_then_unit(&self, path: &Path, f: DirEntriesCallback<'_>) -> Result<()> {


### PR DESCRIPTION
This patch refactory the API to read and write attributes so that the buffer is always provided by the caller.  This means that the caller is not required to always use a 1 kB buffer even if the attribute length is much smaller.

Fixes: https://github.com/trussed-dev/littlefs2/issues/75