### PR TITLE
 Remove dir-entry-path feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           cargo check --workspace --all-targets --all-features
           cargo check --workspace --all-targets --no-default-features
           cargo check --workspace --all-targets --no-default-features --features serde
-          cargo check --workspace --all-targets --no-default-features --features dir-entry-path
 
       - name: Build
         run: cargo build --workspace --release --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `From<littlefs2::path::Error> for littlefs2::io::Error`.
 - Removed `object_safe::OpenOptionsCallback`.
 - Removed `consts::ATTRBYTES_MAX_TYPE`.
+- Removed `dir-entry-path` feature (now always enabled).
 
 [#47]: https://github.com/trussed-dev/littlefs2/pull/47
 [#57]: https://github.com/trussed-dev/littlefs2/pull/57

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 # trybuild = "1"
 
 [features]
-default = ["dir-entry-path", "serde"]
-# use experimental closure-based API
-dir-entry-path = ["littlefs2-core/dir-entry-path"]
+default = ["serde"]
 serde = ["littlefs2-core/serde"]
 # enable assertions in backend C code
 ll-assertions = ["littlefs2-sys/assertions"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,5 +14,4 @@ heapless = "0.7"
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [features]
-dir-entry-path = []
 serde = ["dep:serde"]

--- a/core/src/fs.rs
+++ b/core/src/fs.rs
@@ -115,20 +115,14 @@ impl<'a> Attribute<'a> {
 pub struct DirEntry {
     file_name: PathBuf,
     metadata: Metadata,
-    #[cfg(feature = "dir-entry-path")]
     path: PathBuf,
 }
 
 impl DirEntry {
-    pub fn new(
-        file_name: PathBuf,
-        metadata: Metadata,
-        #[cfg(feature = "dir-entry-path")] path: PathBuf,
-    ) -> Self {
+    pub fn new(file_name: PathBuf, metadata: Metadata, path: PathBuf) -> Self {
         Self {
             file_name,
             metadata,
-            #[cfg(feature = "dir-entry-path")]
             path,
         }
     }
@@ -151,12 +145,10 @@ impl DirEntry {
     /// Returns the full path to the file that this entry represents.
     ///
     /// The full path is created by joining the original path to read_dir with the filename of this entry.
-    #[cfg(feature = "dir-entry-path")]
     pub fn path(&self) -> &Path {
         &self.path
     }
 
-    #[cfg(feature = "dir-entry-path")]
     #[doc(hidden)]
     // This is used in `crypto-service` to "namespace" paths
     // by mutating a DirEntry in-place.

--- a/core/src/object_safe.rs
+++ b/core/src/object_safe.rs
@@ -58,9 +58,7 @@ pub trait DynFilesystem {
     fn available_space(&self) -> Result<usize>;
     fn remove(&self, path: &Path) -> Result<()>;
     fn remove_dir(&self, path: &Path) -> Result<()>;
-    #[cfg(feature = "dir-entry-path")]
     fn remove_dir_all(&self, path: &Path) -> Result<()>;
-    #[cfg(feature = "dir-entry-path")]
     fn remove_dir_all_where(&self, path: &Path, predicate: Predicate<'_>) -> Result<usize>;
     fn rename(&self, from: &Path, to: &Path) -> Result<()>;
     fn exists(&self, path: &Path) -> bool;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -923,7 +923,7 @@ pub struct ReadDir<'a, 'b, S: driver::Storage> {
     // to the field alloc.state, so we cannot assert unique mutable access.
     alloc: RefCell<*mut ReadDirAllocation>,
     fs: &'b Filesystem<'a, S>,
-    path: PathBuf,
+    path: &'b Path,
 }
 
 impl<'a, 'b, S: driver::Storage> Iterator for ReadDir<'a, 'b, S> {
@@ -1012,7 +1012,7 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
     pub unsafe fn read_dir<'b>(
         &'b self,
         alloc: &'b mut ReadDirAllocation,
-        path: &Path,
+        path: &'b Path,
     ) -> Result<ReadDir<'a, 'b, Storage>> {
         // ll::lfs_dir_open stores a copy of the pointer to alloc.state, so
         // we must use addr_of_mut! here, since &mut alloc.state asserts unique
@@ -1026,7 +1026,7 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
         let read_dir = ReadDir {
             alloc: RefCell::new(alloc),
             fs: self,
-            path: PathBuf::from(path),
+            path,
         };
 
         result_from(read_dir, return_code)

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -59,12 +59,10 @@ impl<S: Storage> DynFilesystem for Filesystem<'_, S> {
         Filesystem::remove_dir(self, path)
     }
 
-    #[cfg(feature = "dir-entry-path")]
     fn remove_dir_all(&self, path: &Path) -> Result<()> {
         Filesystem::remove_dir_all(self, path)
     }
 
-    #[cfg(feature = "dir-entry-path")]
     fn remove_dir_all_where(&self, path: &Path, predicate: Predicate<'_>) -> Result<usize> {
         Filesystem::remove_dir_all_where(self, path, &|entry| predicate(entry))
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -396,7 +396,6 @@ fn test_fancy_open() {
 }
 
 #[test]
-#[cfg(feature = "dir-entry-path")]
 fn remove_dir_all_where() {
     let mut backend = Ram::default();
     let mut storage = RamStorage::new(&mut backend);


### PR DESCRIPTION
The dir-entry-path feature has been enabled by default and only adds a very small overhead.  To decrease complexity, this patch removes the feature and always enables the previously feature-gated code.

Fixes: https://github.com/trussed-dev/littlefs2/issues/76