### PR TITLE
core: Make heapless support optional and support multiple versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ jobs:
 
       - name: Check
         run: |
+          cargo check --package littlefs2-core
+          cargo check --package littlefs2-core --features heapless07
+          cargo check --package littlefs2-core --features heapless08
+          cargo check --package littlefs2-core --features serde
+          cargo check --package littlefs2-core --all-features
           cargo check --workspace --all-targets
           cargo check --workspace --all-targets --all-features
           cargo check --workspace --all-targets --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Check
         run: |
           cargo check --package littlefs2-core
+          cargo check --package littlefs2-core --features heapless-bytes03
+          cargo check --package littlefs2-core --features heapless-bytes04
           cargo check --package littlefs2-core --features heapless07
           cargo check --package littlefs2-core --features heapless08
           cargo check --package littlefs2-core --features serde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Change the `set_attribute` function in `DynFilesystem` and `Filesystem` to accept an ID and a slice instead of an `Attribute`.
   - Add a buffer argument to the `attribute` function in `DynFilesystem` and `Filesystem` and return a slice of that buffer containing the read data.
   - Change the `Attribute` struct to store a slice with the read data and the total size of the attribute on the filesystem.
+- Introduce `object_safe::Vec` trait and change `DynFile::read_to_end`, `DynFilesystem::read` and `DynFilesstem::read_chunk` to be generic over a `Vec` implementation to support multiple `heapless` versions (disabled by default).
 
 ### Removed
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,11 @@ repository.workspace = true
 
 [dependencies]
 bitflags = "2.6.0"
-heapless = "0.7"
+heapless07 = { package = "heapless", version = "0.7", optional = true }
+heapless08 = { package = "heapless", version = "0.8", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [features]
+heapless07 = ["dep:heapless07"]
+heapless08 = ["dep:heapless08"]
 serde = ["dep:serde"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,11 +10,15 @@ repository.workspace = true
 
 [dependencies]
 bitflags = "2.6.0"
+heapless-bytes03 = { package = "heapless-bytes", version = "0.3", optional = true }
+heapless-bytes04 = { package = "heapless-bytes", version = "0.4", optional = true }
 heapless07 = { package = "heapless", version = "0.7", optional = true }
 heapless08 = { package = "heapless", version = "0.8", optional = true }
 serde = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [features]
+heapless-bytes03 = ["dep:heapless-bytes03"]
+heapless-bytes04 = ["dep:heapless-bytes04"]
 heapless07 = ["dep:heapless07"]
 heapless08 = ["dep:heapless08"]
 serde = ["dep:serde"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,7 @@ mod path;
 
 pub use fs::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
 pub use io::{Error, OpenSeekFrom, Read, Result, Seek, SeekFrom, Write};
-pub use object_safe::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate};
+pub use object_safe::{DirEntriesCallback, DynFile, DynFilesystem, FileCallback, Predicate, Vec};
 pub use path::{Ancestors, Iter, Path, PathBuf, PathError};
 
 /// Creates a path from a string without a trailing null.

--- a/core/src/object_safe.rs
+++ b/core/src/object_safe.rs
@@ -18,6 +18,30 @@ pub trait Vec: Default + AsRef<[u8]> + AsMut<[u8]> {
     fn truncate(&mut self, n: usize);
 }
 
+#[cfg(feature = "heapless-bytes03")]
+impl<const N: usize> Vec for heapless_bytes03::Bytes<N> {
+    fn resize_to_capacity(&mut self) {
+        heapless_bytes03::Bytes::resize_to_capacity(self)
+    }
+
+    fn truncate(&mut self, n: usize) {
+        use core::ops::DerefMut as _;
+
+        self.deref_mut().truncate(n)
+    }
+}
+
+#[cfg(feature = "heapless-bytes04")]
+impl<const N: usize> Vec for heapless_bytes04::Bytes<N> {
+    fn resize_to_capacity(&mut self) {
+        heapless_bytes04::Bytes::resize_to_capacity(self)
+    }
+
+    fn truncate(&mut self, n: usize) {
+        heapless_bytes04::Bytes::truncate(self, n)
+    }
+}
+
 #[cfg(feature = "heapless07")]
 impl<const N: usize> Vec for heapless07::Vec<u8, N> {
     fn resize_to_capacity(&mut self) {


### PR DESCRIPTION
The `DynFile::read_to_end`, `DynFilesystem::read` and `DynFilesystem::read_chunk` methods use a `heapless::Vec` to store a flexible amount of data.  This patch introduces a `Vec` trait that abstracts over different versions of heapless so that we can optionally support multiple heapless versions at the same time.

Fixes: https://github.com/trussed-dev/littlefs2/issues/77