### PR TITLE
core: Never inline Path to PathBuf conversion

### DIFF
--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -503,6 +503,7 @@ impl PathBuf {
 }
 
 impl From<&Path> for PathBuf {
+    #[inline(never)]
     fn from(path: &Path) -> Self {
         let bytes = path.as_ref().as_bytes();
 


### PR DESCRIPTION
This improves binary size of the Nitrokey 3 firmware.