### PR TITLE
Fix new clippy lints

### DIFF
--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -87,7 +87,7 @@ pub struct Ancestors<'a> {
     path: &'a str,
 }
 
-impl<'a> Iterator for Ancestors<'a> {
+impl Iterator for Ancestors<'_> {
     type Item = PathBuf;
     fn next(&mut self) -> Option<PathBuf> {
         if self.path.is_empty() {
@@ -118,7 +118,7 @@ impl<'a> Iterator for Ancestors<'a> {
     }
 }
 
-impl<'a> FusedIterator for Ancestors<'a> {}
+impl FusedIterator for Ancestors<'_> {}
 
 /// Iterator over the components of a Path
 ///
@@ -127,7 +127,7 @@ pub struct Iter<'a> {
     path: &'a str,
 }
 
-impl<'a> Iterator for Iter<'a> {
+impl Iterator for Iter<'_> {
     type Item = PathBuf;
     fn next(&mut self) -> Option<PathBuf> {
         if self.path.is_empty() {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -936,7 +936,7 @@ pub struct ReadDir<'a, 'b, S: driver::Storage> {
     path: &'b Path,
 }
 
-impl<'a, 'b, S: driver::Storage> Iterator for ReadDir<'a, 'b, S> {
+impl<S: driver::Storage> Iterator for ReadDir<'_, '_, S> {
     type Item = Result<DirEntry>;
 
     // remove this allowance again, once path overflow is properly handled
@@ -972,9 +972,9 @@ impl<'a, 'b, S: driver::Storage> Iterator for ReadDir<'a, 'b, S> {
     }
 }
 
-impl<'a, 'b, S: driver::Storage> ReadDir<'a, 'b, S> {
+impl<'a, S: driver::Storage> ReadDir<'a, '_, S> {
     // Safety-hatch to experiment with missing parts of API
-    pub unsafe fn borrow_filesystem<'c>(&'c mut self) -> &'c Filesystem<'a, S> {
+    pub unsafe fn borrow_filesystem<'b>(&'b mut self) -> &'b Filesystem<'a, S> {
         self.fs
     }
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -573,7 +573,6 @@ impl<'a, 'b, Storage: driver::Storage> File<'a, 'b, Storage> {
     ///
     /// It is equivalent to OpenOptions::new() but allows you to write more readable code.
     /// This also avoids the need to import OpenOptions`.
-
     pub fn with_options() -> OpenOptions {
         OpenOptions::new()
     }


### PR DESCRIPTION
This PR fixes warnings generated by two new clippy lints: unnecessary explicit lifetimes and empty lines after doc comments.