### PR TITLE
core: Make Path and PathBuf more const-friendly and release v0.1.1

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
--
+- Make `Path` and `PathBuf` more const-friendly:
+  - Make `Path::as_ptr` and `PathBuf::from_buffer_unchecked` const.
+  - Add const `Path::const_eq`, `PathBuf::from_path`, `PathBuf::as_path` and `PathBuf::as_str` methods.
 
 ## [v0.1.0](https://github.com/trussed-dev/littlefs2/releases/tag/core-0.1.0) - 2024-10-17
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+-
+
+## [v0.1.1](https://github.com/trussed-dev/littlefs2/releases/tag/core-0.1.1) - 2025-01-16
+
 - Make `Path` and `PathBuf` more const-friendly:
   - Make `Path::as_ptr` and `PathBuf::from_buffer_unchecked` const.
   - Add const `Path::const_eq`, `PathBuf::from_path`, `PathBuf::as_path` and `PathBuf::as_str` methods.

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Make `Path` and `PathBuf` more const-friendly:
   - Make `Path::as_ptr` and `PathBuf::from_buffer_unchecked` const.
   - Add const `Path::const_eq`, `PathBuf::from_path`, `PathBuf::as_path` and `PathBuf::as_str` methods.
+- Add `path_buf` macro to construct a `PathBuf` from a string literal.
 
 ## [v0.1.0](https://github.com/trussed-dev/littlefs2/releases/tag/core-0.1.0) - 2024-10-17
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "littlefs2-core"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Trussed developers"]
 description = "Core types for the littlefs2 crate"
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -59,3 +59,47 @@ macro_rules! path {
         _PATH
     }};
 }
+
+/// Creates an owned path from a string without a trailing null.
+///
+/// Panics and causes a compiler error if the string contains null bytes or non-ascii characters.
+///
+/// # Examples
+///
+/// ```
+/// use littlefs2_core::{path_buf, PathBuf};
+///
+/// const HOME: PathBuf = path_buf!("/home");
+/// let root = path_buf!("/");
+/// ```
+///
+/// Illegal values:
+///
+/// ```compile_fail
+/// # use littlefs2_core::{path_buf, PathBuf};
+/// const WITH_NULL: PathBuf = path_buf!("/h\0me");  // does not compile
+/// ```
+///
+/// ```compile_fail
+/// # use littlefs2_core::{path_buf, PathBuf};
+/// const WITH_UTF8: PathBuf = path_buf!("/höme");  // does not compile
+/// ```
+///
+/// The macro enforces const evaluation so that compilation fails for illegal values even if the
+/// macro is not used in a const context:
+///
+/// ```compile_fail
+/// # use littlefs2_core::path_buf;
+/// let path = path_buf!("te\0st");  // does not compile
+/// ```
+#[macro_export]
+macro_rules! path_buf {
+    ($path:literal) => {{
+        const _PATH: $crate::PathBuf =
+            match $crate::Path::from_str_with_nul(::core::concat!($path, "\0")) {
+                Ok(path) => $crate::PathBuf::from_path(path),
+                Err(_) => panic!("invalid littlefs2 path"),
+            };
+        _PATH
+    }};
+}

--- a/core/src/path.rs
+++ b/core/src/path.rs
@@ -473,11 +473,15 @@ impl PathBuf {
     /// This method is a const-friendly version of the `From<&Path>` implementation.  If you don’t
     /// need a const method, prefer `From<&Path>` as it is more idiomatic and more efficient.
     ///
+    /// The [`path_buf`][`crate::path_buf`] macro can be used instead to construct a `PathBuf` from
+    /// a string literal.
+    ///
     /// # Example
     ///
     /// ```        
-    /// # use littlefs2_core::{path, PathBuf};
+    /// # use littlefs2_core::{path, path_buf, PathBuf};
     /// const PATH: PathBuf = PathBuf::from_path(path!("test"));
+    /// assert_eq!(PATH, path_buf!("test"));
     /// ```
     pub const fn from_path(path: &Path) -> Self {
         let bytes = path.inner.to_bytes();


### PR DESCRIPTION
This patch makes some `Path` and `PathBuf` methods const, adds new `const` helper functions and a `path_buf` macro similar to the existing `path` and releases littlefs2-core v0.1.1 with these changes.