### PR TITLE
ci: Use avr-none target for avr build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,40 +77,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Configure target
-        run: |
-          cat <<EOT > avr-atmega328p.json
-          {
-            "arch": "avr",
-            "atomic-cas": false,
-            "cpu": "atmega328p",
-            "data-layout": "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8",
-            "eh-frame-header": false,
-            "exe-suffix": ".elf",
-            "late-link-args": {
-              "gcc": [
-                "-lgcc"
-              ]
-            },
-            "linker": "avr-gcc",
-            "llvm-target": "avr-unknown-unknown",
-            "max-atomic-width": 8,
-            "no-default-libraries": false,
-            "pre-link-args": {
-              "gcc": [
-                "-mmcu=atmega328p"
-              ]
-            },
-            "relocation-model": "static",
-            "target-c-int-width": "16",
-            "target-pointer-width": "16"
-          }
-          EOT
-
       - name: Patch delog
         run: |
           echo '[patch.crates-io]' >> Cargo.toml
           echo 'delog = { version = "0.1.6", git = "https://github.com/LechevSpace/delog.git", rev = "e83f3fd" }' >> Cargo.toml
 
       - name: Build avr
-        run: cargo +nightly build -Z build-std=core --target=./avr-atmega328p.json --workspace --release
+        run: RUSTFLAGS="-C target-cpu=atmega328p" cargo +nightly build -Z build-std=core --target=avr-none --workspace --release


### PR DESCRIPTION
`avr-none` is now a supported Tier 3 target so we no longer need the custom target definition.