### PR TITLE
Remove trait and result arguments from macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     We use the multiversion feature to keep the old on-disk format (lfs2.0) to not break compatibility with older versions of this crate.
 - Replaced the `version` function with the `BACKEND_VERSION` and `DISK_VERSION` constants.
   - Changed the `Version` struct to be a wrapper for a littlefs version number.
+- Removed the `trait` and `result` arguments from the `const_ram_storage!` and `ram_storage!` macros and replaced them with `$crate::driver::Storage` and `$crate::io::Result`.
 
 ## [v0.5.0](https://github.com/trussed-dev/littlefs2/releases/tag/0.5.0) - 2024-10-25
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1225,8 +1225,6 @@ mod tests {
     use super::*;
     use crate::path;
     use core::convert::TryInto;
-    use driver::Storage as LfsStorage;
-    use io::Result as LfsResult;
     const_ram_storage!(TestStorage, 4096);
 
     #[test]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,11 +3,11 @@
 // `io::Read::read` and `::read_exact`.
 /// A configurable implementation of the Storage trait in memory.
 #[macro_export]
-macro_rules! ram_storage { (
+macro_rules! ram_storage {
+    (
 
     name=$Name:ident,
     backend=$Backend:ident,
-    trait=$StorageTrait:path,
     erase_value=$erase_value:expr,
     read_size=$read_size:expr,
     write_size=$write_size:expr,
@@ -17,7 +17,6 @@ macro_rules! ram_storage { (
     lookahead_size_ty=$lookahead_size:path,
     filename_max_plus_one_ty=$filename_max_plus_one:path,
     path_max_plus_one_ty=$path_max_plus_one:path,
-    result=$Result:ident,
 
 ) => {
         pub struct $Backend {
@@ -43,7 +42,7 @@ macro_rules! ram_storage { (
             }
         }
 
-        impl<'backend> $StorageTrait for $Name<'backend> {
+        impl<'backend> $crate::driver::Storage for $Name<'backend> {
             const READ_SIZE: usize = $read_size;
             const WRITE_SIZE: usize = $write_size;
             type CACHE_SIZE = $cache_size;
@@ -51,7 +50,7 @@ macro_rules! ram_storage { (
             const BLOCK_COUNT: usize = $block_count;
             type LOOKAHEAD_SIZE = $lookahead_size;
 
-            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
+            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $crate::io::Result<usize> {
                 let read_size: usize = Self::READ_SIZE;
                 debug_assert!(offset % read_size == 0);
                 debug_assert!(buf.len() % read_size == 0);
@@ -61,7 +60,7 @@ macro_rules! ram_storage { (
                 Ok(buf.len())
             }
 
-            fn write(&mut self, offset: usize, data: &[u8]) -> $Result<usize> {
+            fn write(&mut self, offset: usize, data: &[u8]) -> $crate::io::Result<usize> {
                 let write_size: usize = Self::WRITE_SIZE;
                 debug_assert!(offset % write_size == 0);
                 debug_assert!(data.len() % write_size == 0);
@@ -71,7 +70,7 @@ macro_rules! ram_storage { (
                 Ok(data.len())
             }
 
-            fn erase(&mut self, offset: usize, len: usize) -> $Result<usize> {
+            fn erase(&mut self, offset: usize, len: usize) -> $crate::io::Result<usize> {
                 let block_size: usize = Self::BLOCK_SIZE;
                 debug_assert!(offset % block_size == 0);
                 debug_assert!(len % block_size == 0);
@@ -84,62 +83,56 @@ macro_rules! ram_storage { (
     };
     ($Name:ident, $Backend:ident, $bytes:expr) => {
         ram_storage!(
-            name=$Name,
-            backend=$Backend,
-            trait=LfsStorage,
-            erase_value=0xff,
-            read_size=1,
-            write_size=1,
-            cache_size_ty=$crate::consts::U32,
-            block_size=128,
-            block_count=$bytes/128,
-            lookahead_size_ty=$crate::consts::U1,
-            filename_max_plus_one_ty=$crate::consts::U256,
-            path_max_plus_one_ty=$crate::consts::U256,
-            result=LfsResult,
+            name = $Name,
+            backend = $Backend,
+            erase_value = 0xff,
+            read_size = 1,
+            write_size = 1,
+            cache_size_ty = $crate::consts::U32,
+            block_size = 128,
+            block_count = $bytes / 128,
+            lookahead_size_ty = $crate::consts::U1,
+            filename_max_plus_one_ty = $crate::consts::U256,
+            path_max_plus_one_ty = $crate::consts::U256,
         );
     };
     (tiny) => {
         ram_storage!(
-            name=RamStorage,
-            backend=Ram,
-            trait=driver::Storage,
-            erase_value=0xff,
-            read_size=32,
-            write_size=32,
-            cache_size_ty=$crate::consts::U32,
-            block_size=128,
-            block_count=8,
-            lookahead_size_ty=$crate::consts::U1,
-            filename_max_plus_one_ty=$crate::consts::U256,
-            path_max_plus_one_ty=$crate::consts::U256,
-            result=Result,
+            name = RamStorage,
+            backend = Ram,
+            erase_value = 0xff,
+            read_size = 32,
+            write_size = 32,
+            cache_size_ty = $crate::consts::U32,
+            block_size = 128,
+            block_count = 8,
+            lookahead_size_ty = $crate::consts::U1,
+            filename_max_plus_one_ty = $crate::consts::U256,
+            path_max_plus_one_ty = $crate::consts::U256,
         );
     };
     (large) => {
         ram_storage!(
-            name=RamStorage,
-            backend=Ram,
-            trait=driver::Storage,
-            erase_value=0xff,
-            read_size=32,
-            write_size=32,
-            cache_size_ty=$crate::consts::U32,
-            block_size=256,
-            block_count=512,
-            lookahead_size_ty=$crate::consts::U4,
-            filename_max_plus_one_ty=$crate::consts::U256,
-            path_max_plus_one_ty=$crate::consts::U256,
-            result=Result,
+            name = RamStorage,
+            backend = Ram,
+            erase_value = 0xff,
+            read_size = 32,
+            write_size = 32,
+            cache_size_ty = $crate::consts::U32,
+            block_size = 256,
+            block_count = 512,
+            lookahead_size_ty = $crate::consts::U4,
+            filename_max_plus_one_ty = $crate::consts::U256,
+            path_max_plus_one_ty = $crate::consts::U256,
         );
     };
 }
 
 #[macro_export]
-macro_rules! const_ram_storage { (
+macro_rules! const_ram_storage {
+    (
 
     name=$Name:ident,
-    trait=$StorageTrait:path,
     erase_value=$erase_value:expr,
     read_size=$read_size:expr,
     write_size=$write_size:expr,
@@ -149,7 +142,6 @@ macro_rules! const_ram_storage { (
     lookahead_size_ty=$lookahead_size:path,
     filename_max_plus_one_ty=$filename_max_plus_one:path,
     path_max_plus_one_ty=$path_max_plus_one:path,
-    result=$Result:ident,
 
 ) => {
         pub struct $Name {
@@ -160,7 +152,9 @@ macro_rules! const_ram_storage { (
             const ERASE_VALUE: u8 = $erase_value;
             pub const fn new() -> Self {
                 // Self::default()
-                Self { buf: [$erase_value; $block_size * $block_count] }
+                Self {
+                    buf: [$erase_value; $block_size * $block_count],
+                }
             }
         }
 
@@ -172,7 +166,7 @@ macro_rules! const_ram_storage { (
             }
         }
 
-        impl $StorageTrait for $Name {
+        impl $crate::driver::Storage for $Name {
             const READ_SIZE: usize = $read_size;
             const WRITE_SIZE: usize = $write_size;
             type CACHE_SIZE = $cache_size;
@@ -180,7 +174,7 @@ macro_rules! const_ram_storage { (
             const BLOCK_COUNT: usize = $block_count;
             type LOOKAHEAD_SIZE = $lookahead_size;
 
-            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $Result<usize> {
+            fn read(&mut self, offset: usize, buf: &mut [u8]) -> $crate::io::Result<usize> {
                 let read_size: usize = Self::READ_SIZE;
                 debug_assert!(offset % read_size == 0);
                 debug_assert!(buf.len() % read_size == 0);
@@ -190,7 +184,7 @@ macro_rules! const_ram_storage { (
                 Ok(buf.len())
             }
 
-            fn write(&mut self, offset: usize, data: &[u8]) -> $Result<usize> {
+            fn write(&mut self, offset: usize, data: &[u8]) -> $crate::io::Result<usize> {
                 let write_size: usize = Self::WRITE_SIZE;
                 debug_assert!(offset % write_size == 0);
                 debug_assert!(data.len() % write_size == 0);
@@ -200,7 +194,7 @@ macro_rules! const_ram_storage { (
                 Ok(data.len())
             }
 
-            fn erase(&mut self, offset: usize, len: usize) -> $Result<usize> {
+            fn erase(&mut self, offset: usize, len: usize) -> $crate::io::Result<usize> {
                 let block_size: usize = Self::BLOCK_SIZE;
                 debug_assert!(offset % block_size == 0);
                 debug_assert!(len % block_size == 0);
@@ -213,18 +207,16 @@ macro_rules! const_ram_storage { (
     };
     ($Name:ident, $bytes:expr) => {
         const_ram_storage!(
-            name=$Name,
-            trait=LfsStorage,
-            erase_value=0xff,
-            read_size=16,
-            write_size=512,
-            cache_size_ty=$crate::consts::U512,
-            block_size=512,
-            block_count=$bytes/512,
-            lookahead_size_ty=$crate::consts::U1,
-            filename_max_plus_one_ty=$crate::consts::U256,
-            path_max_plus_one_ty=$crate::consts::U256,
-            result=LfsResult,
+            name = $Name,
+            erase_value = 0xff,
+            read_size = 16,
+            write_size = 512,
+            cache_size_ty = $crate::consts::U512,
+            block_size = 512,
+            block_count = $bytes / 512,
+            lookahead_size_ty = $crate::consts::U1,
+            filename_max_plus_one_ty = $crate::consts::U256,
+            path_max_plus_one_ty = $crate::consts::U256,
         );
     };
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,42 +2,37 @@ use core::convert::TryInto;
 use generic_array::typenum::consts;
 
 use crate::{
-    driver,
     fs::{Attribute, File, Filesystem},
     io::{Error, OpenSeekFrom, Read, Result, SeekFrom},
     path, BACKEND_VERSION, DISK_VERSION,
 };
 
 ram_storage!(
-    name=OtherRamStorage,
-    backend=OtherRam,
-    trait=driver::Storage,
-    erase_value=0xff,
-    read_size=1,
-    write_size=32,
-    cache_size_ty=consts::U32,
-    block_size=256,
-    block_count=512,
-    lookahead_size_ty=consts::U1,
-    filename_max_plus_one_ty=consts::U256,
-    path_max_plus_one_ty=consts::U256,
-    result=Result,
+    name = OtherRamStorage,
+    backend = OtherRam,
+    erase_value = 0xff,
+    read_size = 1,
+    write_size = 32,
+    cache_size_ty = consts::U32,
+    block_size = 256,
+    block_count = 512,
+    lookahead_size_ty = consts::U1,
+    filename_max_plus_one_ty = consts::U256,
+    path_max_plus_one_ty = consts::U256,
 );
 
 ram_storage!(
-    name=RamStorage,
-    backend=Ram,
-    trait=driver::Storage,
-    erase_value=0xff,
-    read_size=20*5,
-    write_size=20*7,
-    cache_size_ty=consts::U700,
-    block_size=20*35,
-    block_count=32,
-    lookahead_size_ty=consts::U16,
-    filename_max_plus_one_ty=consts::U256,
-    path_max_plus_one_ty=consts::U256,
-    result=Result,
+    name = RamStorage,
+    backend = Ram,
+    erase_value = 0xff,
+    read_size = 20 * 5,
+    write_size = 20 * 7,
+    cache_size_ty = consts::U700,
+    block_size = 20 * 35,
+    block_count = 32,
+    lookahead_size_ty = consts::U16,
+    filename_max_plus_one_ty = consts::U256,
+    path_max_plus_one_ty = consts::U256,
 );
 
 #[test]

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -1,4 +1,4 @@
-use littlefs2::{driver, fs::Filesystem, io::Result, path::Path, ram_storage};
+use littlefs2::{fs::Filesystem, path::Path, ram_storage};
 
 use serde::{Deserialize, Serialize};
 use ssmarshal::{deserialize, serialize};


### PR DESCRIPTION
The `const_ram_storage!` and `ram_storage!` macros used to have trait and result arguments to set the storage trait to implement and the result type to use.  As this defaulted to relative paths, it made the result of the macro dependent on the context and could cause confusion.  At the same time, there is no real use case for substituting these types.

This patch removes the arguments for good and just uses `$crate::driver::Storage` and `$crate::io::Result` instead.

----

As we prepare a breaking release, I’d like to pull in this change that fixes a very annoying macro hygiene issue.