### PR TITLE
Upgrade generic-array to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository.workspace = true
 
 [dependencies]
 delog = "0.1.0"
-generic-array = "0.14"
+generic-array = "1.0"
 heapless = "0.7"
 littlefs2-core = { version = "0.1", path = "core" }
 littlefs2-sys = { version = "0.3.1", features = ["multiversion"] }

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -46,10 +46,10 @@ pub trait Storage {
     /// littlefs uses a read cache, a write cache, and one cache per per file.
     /// Must be a multiple of `READ_SIZE` and `WRITE_SIZE`.
     /// Must be a factor of `BLOCK_SIZE`.
-    type CACHE_SIZE: ArrayLength<u8>;
+    type CACHE_SIZE: ArrayLength;
 
     /// Size of the lookahead buffer used by littlefs, measured in multiples of 8 bytes.
-    type LOOKAHEAD_SIZE: ArrayLength<u64>;
+    type LOOKAHEAD_SIZE: ArrayLength;
 
     ///// Maximum length of a filename plus one. Stored in superblock.
     ///// Should default to 255+1, but associated type defaults don't exist currently.


### PR DESCRIPTION
This PR simply upgrades `generic-array` to the latest stable version.