### PR TITLE
Remove need for generic array and typenum constants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ littlefs2-sys = { version = "0.3.1", features = ["multiversion"] }
 [dev-dependencies]
 ssmarshal = "1"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+clap = { version = "4.5.31", features = ["derive"] }
 # trybuild = "1"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,12 @@ repository.workspace = true
 [package.metadata.docs.rs]
 all-features = true
 
+[[example]]
+name = "list"
+required-features = ["alloc"]
+
 [dependencies]
 delog = "0.1.0"
-generic-array = "0.14"
 heapless = "0.7"
 littlefs2-core = { version = "0.1", path = "core" }
 littlefs2-sys = { version = "0.3.1", features = ["multiversion"] }

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use littlefs2::{
-    consts::{U1, U512},
     driver::Storage,
     fs::{Allocation, FileType, Filesystem},
     io::{Error, Result},
@@ -30,7 +29,7 @@ fn main() {
         file,
         len: actual_len,
     };
-    let mut alloc = Allocation::new();
+    let mut alloc = Allocation::new(&s);
     let fs = Filesystem::mount(&mut alloc, &mut s).expect("failed to mount filesystem");
 
     let available_blocks = fs.available_blocks().unwrap();
@@ -70,13 +69,29 @@ struct FileStorage {
 }
 
 impl Storage for FileStorage {
-    type CACHE_SIZE = U512;
-    type LOOKAHEAD_SIZE = U1;
+    type CACHE_BUFFER = Vec<u8>;
+    type LOOKAHEAD_BUFFER = Vec<u8>;
 
-    const READ_SIZE: usize = 16;
-    const WRITE_SIZE: usize = 512;
-    const BLOCK_SIZE: usize = BLOCK_SIZE;
-    const BLOCK_COUNT: usize = BLOCK_COUNT;
+    fn read_size(&self) -> usize {
+        16
+    }
+    fn write_size(&self) -> usize {
+        512
+    }
+    fn block_size(&self) -> usize {
+        BLOCK_SIZE
+    }
+    fn block_count(&self) -> usize {
+        BLOCK_COUNT
+    }
+
+    fn cache_size(&self) -> usize {
+        512
+    }
+
+    fn lookahead_size(&self) -> usize {
+        1
+    }
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize> {
         assert!(off + buf.len() <= BLOCK_SIZE * BLOCK_COUNT);

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,8 +1,5 @@
 #![allow(non_camel_case_types)]
 
-/// Re-export of `typenum::consts`.
-pub use generic_array::typenum::consts::*;
-
 pub const PATH_MAX: usize = littlefs2_core::PathBuf::MAX_SIZE;
 pub const PATH_MAX_PLUS_ONE: usize = littlefs2_core::PathBuf::MAX_SIZE_PLUS_ONE;
 pub const FILENAME_MAX_PLUS_ONE: u32 = 255 + 1;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,16 +7,12 @@ use core::{
     cell::{RefCell, UnsafeCell},
     mem, slice,
 };
-use generic_array::typenum::marker_traits::Unsigned;
 use littlefs2_sys as ll;
-
-// so far, don't need `heapless-bytes`.
-pub type Bytes<SIZE> = generic_array::GenericArray<u8, SIZE>;
 
 pub use littlefs2_core::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
 
 use crate::{
-    driver,
+    driver::{self, Buffer},
     io::{self, Error, OpenSeekFrom, Result},
     path::{Path, PathBuf},
     DISK_VERSION,
@@ -44,25 +40,22 @@ pub fn u32_result(return_value: i32) -> Result<u32> {
 }
 
 struct Cache<Storage: driver::Storage> {
-    read: UnsafeCell<Bytes<Storage::CACHE_SIZE>>,
-    write: UnsafeCell<Bytes<Storage::CACHE_SIZE>>,
+    read: UnsafeCell<Storage::CACHE_BUFFER>,
+    write: UnsafeCell<Storage::CACHE_BUFFER>,
     // lookahead: aligned::Aligned<aligned::A4, Bytes<Storage::LOOKAHEAD_SIZE>>,
-    lookahead: UnsafeCell<generic_array::GenericArray<u64, Storage::LOOKAHEAD_SIZE>>,
+    lookahead: UnsafeCell<Storage::CACHE_BUFFER>,
+    size: usize,
 }
 
 impl<S: driver::Storage> Cache<S> {
-    pub fn new() -> Self {
+    pub fn new(storage: &S) -> Self {
+        let cache_size = storage.cache_size();
         Self {
-            read: Default::default(),
-            write: Default::default(),
-            lookahead: Default::default(),
+            read: UnsafeCell::new(S::CACHE_BUFFER::with_capacity(cache_size)),
+            write: UnsafeCell::new(S::CACHE_BUFFER::with_capacity(cache_size)),
+            lookahead: UnsafeCell::new(S::CACHE_BUFFER::with_capacity(cache_size)),
+            size: cache_size,
         }
-    }
-}
-
-impl<S: driver::Storage> Default for Cache<S> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -72,22 +65,15 @@ pub struct Allocation<Storage: driver::Storage> {
     state: ll::lfs_t,
 }
 
-// pub fn check_storage_requirements(
-
-impl<Storage: driver::Storage> Default for Allocation<Storage> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 impl<Storage: driver::Storage> Allocation<Storage> {
-    pub fn new() -> Allocation<Storage> {
-        let read_size: u32 = Storage::READ_SIZE as _;
-        let write_size: u32 = Storage::WRITE_SIZE as _;
-        let block_size: u32 = Storage::BLOCK_SIZE as _;
-        let cache_size: u32 = <Storage as driver::Storage>::CACHE_SIZE::U32;
-        let lookahead_size: u32 = 8 * <Storage as driver::Storage>::LOOKAHEAD_SIZE::U32;
-        let block_cycles: i32 = Storage::BLOCK_CYCLES as _;
-        let block_count: u32 = Storage::BLOCK_COUNT as _;
+    pub fn new(storage: &Storage) -> Allocation<Storage> {
+        let read_size: u32 = storage.read_size() as _;
+        let write_size: u32 = storage.write_size() as _;
+        let block_size: u32 = storage.block_size() as _;
+        let cache_size: u32 = storage.cache_size() as _;
+        let lookahead_size: u32 = 8 * storage.lookahead_size() as u32;
+        let block_cycles: i32 = storage.block_cycles() as _;
+        let block_count: u32 = storage.block_count() as _;
 
         debug_assert!(block_cycles >= -1);
         debug_assert!(block_cycles != 0);
@@ -113,7 +99,7 @@ impl<Storage: driver::Storage> Allocation<Storage> {
         debug_assert!(cache_size <= block_size);
         debug_assert!(block_size % cache_size == 0);
 
-        let cache = Cache::new();
+        let cache = Cache::new(storage);
 
         let filename_max_plus_one: u32 = crate::consts::FILENAME_MAX_PLUS_ONE;
         debug_assert!(filename_max_plus_one > 1);
@@ -182,6 +168,7 @@ impl<Storage: driver::Storage> Allocation<Storage> {
 // also consider "erasing" the lifetime completely
 pub struct Filesystem<'a, Storage: driver::Storage> {
     alloc: RefCell<&'a mut Allocation<Storage>>,
+    cache_size: usize,
     storage: &'a mut Storage,
 }
 
@@ -203,12 +190,12 @@ struct RemoveDirAllProgress {
 }
 
 impl<Storage: driver::Storage> Filesystem<'_, Storage> {
-    pub fn allocate() -> Allocation<Storage> {
-        Allocation::new()
+    pub fn allocate(storage: &Storage) -> Allocation<Storage> {
+        Allocation::new(storage)
     }
 
     pub fn format(storage: &mut Storage) -> Result<()> {
-        let alloc = &mut Allocation::new();
+        let alloc = &mut Allocation::new(storage);
         let fs = Filesystem::new(alloc, storage);
         let mut alloc = fs.alloc.borrow_mut();
         let return_code = unsafe { ll::lfs_format(&mut alloc.state, &alloc.config) };
@@ -217,7 +204,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
 
     // TODO: check if this is equivalent to `is_formatted`.
     pub fn is_mountable(storage: &mut Storage) -> bool {
-        let alloc = &mut Allocation::new();
+        let alloc = &mut Allocation::new(storage);
         Filesystem::mount(alloc, storage).is_ok()
     }
 
@@ -233,19 +220,19 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         storage: &mut Storage,
         f: impl FnOnce(&Filesystem<'_, Storage>) -> Result<R>,
     ) -> Result<R> {
-        let mut alloc = Allocation::new();
+        let mut alloc = Allocation::new(storage);
         let fs = Filesystem::mount(&mut alloc, storage)?;
         f(&fs)
     }
 
     /// Total number of blocks in the filesystem
     pub fn total_blocks(&self) -> usize {
-        Storage::BLOCK_COUNT
+        self.storage.block_count()
     }
 
     /// Total number of bytes in the filesystem
     pub fn total_space(&self) -> usize {
-        Storage::BLOCK_COUNT * Storage::BLOCK_SIZE
+        self.storage.block_count() * self.storage.block_size()
     }
 
     /// Available number of unused blocks in the filesystem
@@ -270,7 +257,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
     /// Second, files may be inlined.
     pub fn available_space(&self) -> Result<usize> {
         self.available_blocks()
-            .map(|blocks| blocks * Storage::BLOCK_SIZE)
+            .map(|blocks| blocks * self.storage.block_size())
     }
 
     /// Remove a file or directory.
@@ -512,7 +499,7 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
         let storage = unsafe { &mut *((*c).context as *mut Storage) };
         debug_assert!(!c.is_null());
         // let block_size = unsafe { c.read().block_size };
-        let block_size = Storage::BLOCK_SIZE as u32;
+        let block_size = storage.block_size() as u32;
         let off = (block * block_size + off) as usize;
         let buf: &[u8] = unsafe { slice::from_raw_parts(buffer as *const u8, size as usize) };
 
@@ -524,9 +511,9 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
     extern "C" fn lfs_config_erase(c: *const ll::lfs_config, block: ll::lfs_block_t) -> c_int {
         // println!("in lfs_config_erase");
         let storage = unsafe { &mut *((*c).context as *mut Storage) };
-        let off = block as usize * Storage::BLOCK_SIZE;
+        let off = block as usize * storage.block_size();
 
-        error_code_from(storage.erase(off, Storage::BLOCK_SIZE))
+        error_code_from(storage.erase(off, storage.block_size()))
     }
 
     /// C callback interface used by LittleFS to sync data with the lower level interface below the
@@ -540,22 +527,21 @@ impl<Storage: driver::Storage> Filesystem<'_, Storage> {
 
 /// The state of a `File`. Pre-allocate with `File::allocate`.
 pub struct FileAllocation<S: driver::Storage> {
-    cache: UnsafeCell<Bytes<S::CACHE_SIZE>>,
+    cache: UnsafeCell<S::CACHE_BUFFER>,
+    cache_size: usize,
     state: ll::lfs_file_t,
     config: ll::lfs_file_config,
 }
 
-impl<S: driver::Storage> Default for FileAllocation<S> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<S: driver::Storage> FileAllocation<S> {
-    pub fn new() -> Self {
-        let cache_size: u32 = <S as driver::Storage>::CACHE_SIZE::to_u32();
+    pub fn new(cache_size: usize) -> Self {
         debug_assert!(cache_size > 0);
-        unsafe { mem::MaybeUninit::zeroed().assume_init() }
+        Self {
+            cache: UnsafeCell::new(S::CACHE_BUFFER::with_capacity(cache_size)),
+            cache_size,
+            state: unsafe { mem::MaybeUninit::zeroed().assume_init() },
+            config: unsafe { mem::MaybeUninit::zeroed().assume_init() },
+        }
     }
 }
 
@@ -567,8 +553,8 @@ pub struct File<'a, 'b, S: driver::Storage> {
 }
 
 impl<'a, 'b, Storage: driver::Storage> File<'a, 'b, Storage> {
-    pub fn allocate() -> FileAllocation<Storage> {
-        FileAllocation::new()
+    pub fn allocate(fs: &Filesystem<'_, Storage>) -> FileAllocation<Storage> {
+        FileAllocation::new(fs.cache_size)
     }
 
     /// Returns a new OpenOptions object.
@@ -756,7 +742,8 @@ impl OpenOptions {
         alloc: &mut FileAllocation<S>,
         path: &Path,
     ) -> Result<File<'a, 'b, S>> {
-        alloc.config.buffer = alloc.cache.get() as *mut _;
+        assert_eq!(fs.cache_size, alloc.cache_size);
+        alloc.config.buffer = alloc.cache.get_mut().as_mut_ptr() as *mut _;
         // We need to use addr_of_mut! here instead of & mut since
         // the FFI stores a copy of a pointer to the field state,
         // so we cannot assert unique mutable access.
@@ -783,7 +770,7 @@ impl OpenOptions {
         path: &Path,
         f: impl FnOnce(&File<'a, '_, S>) -> Result<R>,
     ) -> Result<R> {
-        let mut alloc = FileAllocation::new(); // lifetime 'c
+        let mut alloc = File::allocate(fs); // lifetime 'c
         let mut file = unsafe { self.open(fs, &mut alloc, path)? };
         // Q: what is the actually correct behaviour?
         // E.g. if res is Ok but closing gives an error.
@@ -1082,11 +1069,12 @@ impl<'a, Storage: driver::Storage> Filesystem<'a, Storage> {
     fn new(alloc: &'a mut Allocation<Storage>, storage: &'a mut Storage) -> Self {
         alloc.config.context = storage as *mut _ as *mut c_void;
 
-        alloc.config.read_buffer = alloc.cache.read.get() as *mut c_void;
-        alloc.config.prog_buffer = alloc.cache.write.get() as *mut c_void;
-        alloc.config.lookahead_buffer = alloc.cache.lookahead.get() as *mut c_void;
+        alloc.config.read_buffer = alloc.cache.read.get_mut().as_mut_ptr() as *mut c_void;
+        alloc.config.prog_buffer = alloc.cache.write.get_mut().as_mut_ptr() as *mut c_void;
+        alloc.config.lookahead_buffer = alloc.cache.lookahead.get_mut().as_mut_ptr() as *mut c_void;
 
         Filesystem {
+            cache_size: alloc.cache.size,
             alloc: RefCell::new(alloc),
             storage,
         }
@@ -1364,7 +1352,7 @@ mod tests {
         })
         .unwrap();
 
-        let mut alloc = Allocation::new();
+        let mut alloc = Allocation::new(&test_storage);
         let fs = Filesystem::mount(&mut alloc, &mut test_storage).unwrap();
         // fs.write(b"/z.txt\0".try_into().unwrap(), &jackson5).unwrap();
         fs.write(path!("z.txt"), jackson5).unwrap();
@@ -1475,11 +1463,11 @@ mod tests {
                 Ok(())
             })?;
 
-            let mut a1 = File::allocate();
+            let mut a1 = File::allocate(fs);
             let f1 = unsafe { File::create(fs, &mut a1, b"a.txt\0".try_into().unwrap())? };
             f1.write(b"some text")?;
 
-            let mut a2 = File::allocate();
+            let mut a2 = File::allocate(fs);
             let f2 = unsafe { File::create(fs, &mut a2, b"b.txt\0".try_into().unwrap())? };
             f2.write(b"more text")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ let mut storage = RamStorage::new(&mut ram);
 // must format before first mount
 Filesystem::format(&mut storage).unwrap();
 // must allocate state statically before use
-let mut alloc = Filesystem::allocate();
+let mut alloc = Filesystem::allocate(&storage);
 let mut fs = Filesystem::mount(&mut alloc, &mut storage).unwrap();
 
 // may use common `OpenOptions`

--- a/src/object_safe.rs
+++ b/src/object_safe.rs
@@ -1,7 +1,5 @@
 //! Object-safe traits for [`File`][], [`Filesystem`][] and [`Storage`][].
 
-use generic_array::typenum::Unsigned as _;
-
 use crate::{
     driver::Storage,
     fs::{Attribute, File, FileOpenFlags, Filesystem, Metadata},
@@ -179,31 +177,31 @@ pub trait DynStorage {
 
 impl<S: Storage> DynStorage for S {
     fn read_size(&self) -> usize {
-        Self::READ_SIZE
+        <S as Storage>::read_size(self)
     }
 
     fn write_size(&self) -> usize {
-        Self::WRITE_SIZE
+        <S as Storage>::write_size(self)
     }
 
     fn block_size(&self) -> usize {
-        Self::BLOCK_SIZE
+        <S as Storage>::block_size(self)
     }
 
     fn block_count(&self) -> usize {
-        Self::BLOCK_COUNT
+        <S as Storage>::block_count(self)
     }
 
     fn block_cycles(&self) -> isize {
-        Self::BLOCK_CYCLES
+        <S as Storage>::block_cycles(self)
     }
 
     fn cache_size(&self) -> usize {
-        S::CACHE_SIZE::to_usize()
+        <S as Storage>::cache_size(self)
     }
 
     fn lookahead_size(&self) -> usize {
-        S::LOOKAHEAD_SIZE::to_usize()
+        <S as Storage>::lookahead_size(self)
     }
 
     fn read(&mut self, off: usize, buf: &mut [u8]) -> Result<usize> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 use core::convert::TryInto;
-use generic_array::typenum::consts;
 
 use crate::{
     fs::{Attribute, File, Filesystem},
@@ -13,12 +12,10 @@ ram_storage!(
     erase_value = 0xff,
     read_size = 1,
     write_size = 32,
-    cache_size_ty = consts::U32,
+    cache_size = 32,
     block_size = 256,
     block_count = 512,
-    lookahead_size_ty = consts::U1,
-    filename_max_plus_one_ty = consts::U256,
-    path_max_plus_one_ty = consts::U256,
+    lookahead_size = 1,
 );
 
 ram_storage!(
@@ -27,12 +24,10 @@ ram_storage!(
     erase_value = 0xff,
     read_size = 20 * 5,
     write_size = 20 * 7,
-    cache_size_ty = consts::U700,
+    cache_size = 700,
     block_size = 20 * 35,
     block_count = 32,
-    lookahead_size_ty = consts::U16,
-    filename_max_plus_one_ty = consts::U256,
-    path_max_plus_one_ty = consts::U256,
+    lookahead_size = 16,
 );
 
 #[test]
@@ -45,7 +40,7 @@ fn version() {
 fn format() {
     let mut backend = OtherRam::default();
     let mut storage = OtherRamStorage::new(&mut backend);
-    let mut alloc = Filesystem::allocate();
+    let mut alloc = Filesystem::allocate(&storage);
 
     // should fail: FS is not formatted
     assert_eq!(
@@ -77,7 +72,7 @@ fn borrow_fs_allocation() {
     let mut backend = OtherRam::default();
 
     let mut storage = OtherRamStorage::new(&mut backend);
-    let mut alloc_fs = Filesystem::allocate();
+    let mut alloc_fs = Filesystem::allocate(&storage);
     Filesystem::format(&mut storage).unwrap();
     let _fs = Filesystem::mount(&mut alloc_fs, &mut storage).unwrap();
     // previous `_fs` is fine as it's masked, due to NLL
@@ -94,7 +89,7 @@ fn borrow_fs_allocation2() {
     let mut backend = OtherRam::default();
 
     let mut storage = OtherRamStorage::new(&mut backend);
-    let mut alloc_fs = Filesystem::allocate();
+    let mut alloc_fs = Filesystem::allocate(&storage);
     Filesystem::format(&mut storage).unwrap();
     let _fs = Filesystem::mount(&mut alloc_fs, &mut storage).unwrap();
     // previous `_fs` is fine as it's masked, due to NLL

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -19,7 +19,7 @@ fn main() {
     let mut storage = RamStorage::new(&mut ram);
     Filesystem::format(&mut storage).unwrap();
 
-    let mut alloc = Filesystem::allocate();
+    let mut alloc = Filesystem::allocate(&storage);
     let fs = Filesystem::mount(&mut alloc, &mut storage).unwrap();
 
     let entity = Entity::default();


### PR DESCRIPTION
This also allows for more flexible `Storage` implementations that use `Vec<u8>` as a cache buffer and are not fixed to a single block size, this is used in the `list` example to allow listing filesystem with varying block sizes without requiring recompilation.