### PR TITLE
Add disk-version features flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ delog = "0.1.0"
 generic-array = "0.14"
 heapless = "0.7"
 littlefs2-core = { version = "0.1", path = "core" }
-littlefs2-sys = { version = "0.3.1", features = ["multiversion"] }
+littlefs2-sys = { version = "0.3.1" }
 
 [dev-dependencies]
 ssmarshal = "1"
@@ -36,7 +36,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 # trybuild = "1"
 
 [features]
-default = ["serde"]
+default = ["disk-version-20", "serde"]
 alloc = []
 serde = ["littlefs2-core/serde"]
 # enable assertions in backend C code
@@ -44,6 +44,9 @@ ll-assertions = ["littlefs2-sys/assertions"]
 # enable trace in backend C code
 ll-trace = ["littlefs2-sys/trace"]
 c-stubs = []
+multiversion = ["littlefs2-sys/multiversion"]
+disk-version-20 = ["multiversion"]
+disk-version-21 = ["multiversion"]
 
 log-all = []
 log-none = []

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -15,11 +15,12 @@ pub type Bytes<SIZE> = generic_array::GenericArray<u8, SIZE>;
 
 pub use littlefs2_core::{Attribute, DirEntry, FileOpenFlags, FileType, Metadata};
 
+#[cfg(feature = "multiversion")]
+use crate::DISK_VERSION;
 use crate::{
     driver,
     io::{self, Error, OpenSeekFrom, Result},
     path::{Path, PathBuf},
-    DISK_VERSION,
 };
 
 fn error_code_from<T>(result: Result<T>) -> ll::lfs_error {
@@ -179,6 +180,7 @@ impl<Storage: driver::Storage> Allocation<Storage> {
             compact_thresh: 0,
             metadata_max: 0,
             inline_max: 0,
+            #[cfg(feature = "multiversion")]
             disk_version: DISK_VERSION.into(),
             flags: config.mount_flags.bits(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,10 +173,21 @@ pub const BACKEND_VERSION: Version = Version(ll::LFS_VERSION);
 
 /// The on-disk version used by [`Filesystem`][`fs::Filesystem`].
 ///
-/// Note that this is not the same as the littlefs [`LFS_DISK_VERSION`][`ll::LFS_DISK_VERSION`]
-/// constant as this crate uses the multiversion feature to select on-disk version 2.0 instead of
-/// using the latest on-disk version (currently 2.1).
-pub const DISK_VERSION: Version = Version(0x0002_0000);
+/// The value is defined only if feature `multiversion` is enabled.
+/// If none of `disk-version-20` or `disk-version-21` features are enabled,
+/// defaults to littlefs [`LFS_DISK_VERSION`][`ll::LFS_DISK_VERSION`].
+#[cfg(feature = "multiversion")]
+pub const DISK_VERSION: Version = {
+    #[cfg(all(feature = "disk-version-20", feature = "disk-version-21"))]
+    compile_error!("features `disk-version-20` and `disk-version-21` are mutually exclusive");
+    if cfg!(feature = "disk-version-20") {
+        Version(0x0002_0000)
+    } else if cfg!(feature = "disk-version-21") {
+        Version(0x0002_0001)
+    } else {
+        Version(ll::LFS_DISK_VERSION)
+    }
+};
 
 /// A littlefs version number.
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
`disk-version-20` is part of defaults features for backward compatibility
If `multiversion` feature is enabled without any `disk-version-*` feature, we use littlefs disk version.